### PR TITLE
Remove need to use `cookbook:` prefix when specifying recipe

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-  "name": "cookbook",
   "license": "MIT",
   "devDependencies": {
     "parcel": "^1.12.4",

--- a/recipes/RoutingHashHalogen/README.md
+++ b/recipes/RoutingHashHalogen/README.md
@@ -2,7 +2,7 @@
 From the top repo directory, run:
 ```
 npm run build
-npm run serve --cookbook:recipe=RoutingHashHalogen
+npm run serve --recipe=RoutingHashHalogen
 ```
 
 When you click on the links, you should see:

--- a/recipes/RoutingHashLog/README.md
+++ b/recipes/RoutingHashLog/README.md
@@ -2,7 +2,7 @@
 From the top repo directory, run:
 ```
 npm run build
-npm run serve --cookbook:recipe=RoutingHashLog
+npm run serve --recipe=RoutingHashLog
 ```
 
 Then open up the browser console, and click on the links.

--- a/recipes/RoutingPushHalogen/README.md
+++ b/recipes/RoutingPushHalogen/README.md
@@ -2,7 +2,7 @@
 From the top repo directory, run:
 ```
 npm run build
-npm run serve --cookbook:recipe=RoutingPushHalogen
+npm run serve --recipe=RoutingPushHalogen
 ```
 
 When you click on the links, you should see:

--- a/recipes/Template/README.md
+++ b/recipes/Template/README.md
@@ -4,8 +4,8 @@
 From the top repo directory, run:
 ```
 npm run build
-npm run run --cookbook:recipe=Template
-npm run serve --cookbook:recipe=Template
+npm run run --recipe=Template
+npm run serve --recipe=Template
 ```
 
 ## Problem Description
@@ -19,4 +19,3 @@ This example shows how to run a simple "hello world" program in either the node.
 - `purescript-prelude`
 - `purescript-effect`
 - `purescript-console`
-


### PR DESCRIPTION
Fixes #13 