### PR TITLE
Add note about not adding/overriding packages in `packages.dhall` file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,21 @@ The recipes folder contains all the recipes in this repo in no particular order.
 
 ## Contributing new recipes
 
+### Principles
+
+#### Only use packages in the latest package set release
+
+In other words, we do not allow anyone to override or add packages in the `packages.dhall` file. If one overrided a given package to make Recipe A work, it might break Recipe B that also relies upon that package. If one added a package that isn't later maintained, it might prevent our CI from passing, which can delay new recipes from being added to this cookbook.
+Thus, if you want to use a package that's not in the package set, please add it to the package set. If you want to override a package, please update it in the package set. No exceptions.
+
+### Instructions
+
 Follow these instructions for contributing new recipes:
 1. Open a new issue making a request for a recipe. This helps avoid two developers working on the same recipe independently.
 1. Pick an existing recipe to duplicate as a starting point. The `Template` recipe is probably the simplest".
 1. Rename the copied folder to a short description of the problem you're trying to solve using PascalCase (e.g. RoutingPushHalogen)
 1. If your recipe is incompatible with the browser enviornment (e.g. reading local files with node), delete the `dev` directory. Note that just logging to the console **is** supported in the browser.
 1. Use your recipe name to prefix all modules. Do a quick search to find all instances of the old recipe name to replace (e.g. `grep -r RoutingPushHalogen .`).
-1. If needed, update the `packages.dhall` file to include more packages.
 1. Install needed dependencies via `spago install <packageName>`
 1. Implement your recipe
 1. Rember to update your recipe's readme

--- a/README.md
+++ b/README.md
@@ -10,8 +10,14 @@ The recipes folder contains all the recipes in this repo in no particular order.
 
 #### Only use packages in the latest package set release
 
-In other words, we do not allow anyone to override or add packages in the `packages.dhall` file. If one overrided a given package to make Recipe A work, it might break Recipe B that also relies upon that package. If one added a package that isn't later maintained, it might prevent our CI from passing, which can delay new recipes from being added to this cookbook.
-Thus, if you want to use a package that's not in the package set, please add it to the package set. If you want to override a package, please update it in the package set. No exceptions.
+In other words, we do not allow anyone to override or add packages in the `packages.dhall` file for the following reasons:
+- Reduces the burden of maintenance for maintainers of this repo
+- Overriding package A to make Recipe X work now might prevent Recipe Y from working (which doesn't need the override)
+- Somewhat reduces the attack surface of malicious recipes (e.g. including a malicious package via addition/override)
+
+Thus, if you want to use a package that's not in the package set, please add it to the package set. Any PRs that use packages not in the package set will not be merged until all of their packages are in the package set.
+
+By implication, recipes that use packages that get dropped from the package set will be moved to a temporary holding folder. If the recipe doesn't get updated within a month, the recipe will be dropped.
 
 ### Instructions
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ In other words, we do not allow anyone to override or add packages in the `packa
 
 Thus, if you want to use a package that's not in the package set, please add it to the package set. Any PRs that use packages not in the package set will not be merged until all of their packages are in the package set.
 
-By implication, recipes that use packages that get dropped from the package set will be moved to a temporary holding folder. If the recipe doesn't get updated within a month, the recipe will be dropped.
+By implication, recipes that use packages that get dropped from the package set will be moved to the `broken-recipes` folder.
 
 ### Instructions
 


### PR DESCRIPTION
Fixes #8 

If this "contributing a new recipe" section gets too big or should appear in a CONTRIBUTING.md file, we can do that later.