### PR TITLE
Fail if config not set correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "purescript": "^0.13.8",
     "spago": "^0.15.2"
   },
-  "config": {"recipe": "Template"},
+  "config": {"recipe": "RecipeNameMissing"},
   "scripts": {
     "build": "spago build",
     "run": "spago run --main $npm_package_config_recipe.Main",


### PR DESCRIPTION
#16 passed because it just used the `Template` placeholder in the config. If you run `npm run serve --recipe=RoutingHashLog` it actually launches the `Template`.

This PR changes the placeholder so it fails instead.

Unfortunately, the npm logs in the failing case are not helpful since the variables are not expanded. (see https://github.com/npm/cli/issues/1417). Users would get a better clue to what's wrong if the logs were like this:

```
> parcel recipes/RecipeNameMissing/dev/index.html --out-dir recipes/RecipeNameMissing/dev-dist --open
```

But instead we just get this:
```
npm run serve --recipe=RoutingHashLog

> @ serve /home/miles/projects/purescript/cookbook
> parcel recipes/$npm_package_config_recipe/dev/index.html --out-dir recipes/$npm_package_config_recipe/dev-dist --open

Server running at http://localhost:1234 
🚨  No entries found.
    at Bundler.bundle (/home/miles/.nvm/versions/node/v13.12.0/lib/node_modules/parcel/src/Bundler.js:275:17)
    at async Bundler.serve (/home/miles/.nvm/versions/node/v13.12.0/lib/node_modules/parcel/src/Bundler.js:842:7)
    at async Command.bundle (/home/miles/.nvm/versions/node/v13.12.0/lib/node_modules/parcel/src/cli.js:241:20)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @ serve: `parcel recipes/$npm_package_config_recipe/dev/index.html --out-dir recipes/$npm_package_config_recipe/dev-dist --open`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the @ serve script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm WARN Local package.json exists, but node_modules missing, did you mean to install?

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/miles/.npm/_logs/2020-06-12T15_09_27_569Z-debug.log
```

Maybe we should pivot to using a makefile instead, which is a much more capable tool.
