### PR TITLE
Edit packages in table

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ If you want to contribute a new recipe, see the [CONTRIBUTING.md](./CONTRIBUTING
 
 | Recipe | Description | Packages | Node | Browser |
 | - | - | - | - | - |
-| [HelloWorld](./recipes/HelloWorld) | Prints "Hello World" to console | `effect`, `console`, `prelude` | x | x |
-| [RoutingHashHalogen](./recipes/RoutingHashHalogen) | Do hash-based routing in a Halogen SPA |   |   | x |
-| [RoutingPushHalogen](./recipes/RoutingPushHalogen) | Do push-state-based routing in a Halogen SPA |   |   | x |
-| [RoutingLog](./recipes/RoutingLog) | Log the routes created via the `rouing` library |   | x | x |
+| [HelloWorld](./recipes/HelloWorld) | Prints "Hello World" to console | `effect`, `console`| x | x |
+| [RoutingHashHalogen](./recipes/RoutingHashHalogen) | Do hash-based routing in a Halogen SPA | `routing`, `generics-rep`, `halogen`, `effect`, `console` |   | x |
+| [RoutingPushHalogen](./recipes/RoutingPushHalogen) | Do push-state-based routing in a Halogen SPA | `routing`, `generics-rep`, `halogen`, `effect`, `console` |   | x |
+| [RoutingLog](./recipes/RoutingLog) | Log the routes created via the `rouing` library | `routing`, `generics-rep`, `effect`, `console` | x | x |


### PR DESCRIPTION
`prelude` is implied, and doesn't need to be explicitly listed in `spago.dhall`.

I'm wondering if `console` and `effect` are worth listing either. It makes this list pretty busy. Maybe we should just list additions beyond what's available by default after `spago init`.