### PR TITLE
Run `make buildAllDev` when running CI to build all recipes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ install:
   - npm install
 script:
   - npm run build
+  - make buildAllDev


### PR DESCRIPTION
We don't currently run the full build command when recipes use `parcel`. This fixes that.