### PR TITLE
Use .ONESHELL and run recipes' CI based on backend compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,9 @@ branches:
 install:
   - npm install
 script:
-  - diff README.md <(scripts/generateRecipeTable.sh)
   - make testAllCommands
+  - echo "\n\n\n"
+  - diff README.md <(scripts/generateRecipeTable.sh)
   - make testAllCI
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ install:
   - npm install
 script:
   - diff README.md <(scripts/generateRecipeTable.sh)
-  - make testAllCI
   - make testAllCommands
+  - make testAllCI
 cache:
   directories:
    - output

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ install:
   - npm install
 script:
   - make testAllCommands
-  - echo "\n\n\n"
   - diff README.md <(scripts/generateRecipeTable.sh)
   - make testAllCI
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,8 @@ install:
   - npm install
 script:
   - diff README.md <(scripts/generateRecipeTable.sh)
-  - make buildAll
-  - make runAllNode
-  - make buildAllWeb
+  - make testAllCI
+  - make testAllCommands
 cache:
   directories:
    - output

--- a/makefile
+++ b/makefile
@@ -36,6 +36,14 @@ MAKEFLAGS += --no-builtin-rules
 
 # ===== Makefile - Repo Commands =====
 
+# Variables get that a list of all recipes that can be run on
+# Node.js or browser backends
+#
+#   wildcard = expand globs and add a space in-between each one
+#   patsubst = patsubst(textToFind,replaceItWithThisText,originalText)
+targetsNode := $(patsubst recipes/%/nodeSupported.md,%-node,$(wildcard recipes/*/nodeSupported.md))
+targetsWeb := $(patsubst recipes/%/web,%-web,$(wildcard recipes/*/web))
+
 # Note: usages of `.PHONY: <target>` mean the target name is not an actual file
 # .PHONY: targetName
 

--- a/makefile
+++ b/makefile
@@ -142,19 +142,22 @@ recipes/%/web:
 %-buildWeb: $(call recipeDir,%) $(call webDir,%) %-build
 > parcel build $(call webHtml,$*) --out-dir $(call webDistDir,$*) --no-minify --no-source-maps
 
+# Note: `%-buildProd` and its related commands were commented out
+# because the command doesn't currently work.
+
 # How to make prodDir
-recipes/%/prod:
-> mkdir -p $@
+# recipes/%/prod:
+# > mkdir -p $@
 
 # How to make prodHtml
-recipes/%/prod/index.html: $(call prodDir,%)
-> cp $(call webHtml,$*) $(call prodDir,$*)
+# recipes/%/prod/index.html: $(call prodDir,%)
+# > cp $(call webHtml,$*) $(call prodDir,$*)
 
 # Creates a minified production build.
 # For reference.
-%-buildProd: $(call recipeDir,%) $(call webDir,%) $(call prodHtml,%)
-> spago -x $(call recipeSpago,$*) bundle-app --main $(call main,$*) --to $(call prodJs,$*)
-> parcel build $(call prodHtml,$*) --out-dir $(call prodDistDir,$*)
+# %-buildProd: $(call recipeDir,%) $(call webDir,%) $(call prodHtml,%)
+# > spago -x $(call recipeSpago,$*) bundle-app --main $(call main,$*) --to $(call prodJs,$*)
+# > parcel build $(call prodHtml,$*) --out-dir $(call prodDistDir,$*)
 
 # ===== Makefile - CI Commands =====
 
@@ -192,4 +195,4 @@ testAllCommands:
 > $(MAKE) HelloWorld-build
 > $(MAKE) HelloWorld-buildWeb
 > $(MAKE) HelloWorld-testCI
-> $(MAKE) HelloWorld-buildProd
+# > $(MAKE) HelloWorld-buildProd


### PR DESCRIPTION
Fixes #14
Fixes #10

Current issue: `%-buildProd` fails to build because [`make` thinks `HelloWorld/prod/index.html` is a recipe name](https://travis-ci.com/github/JordanMartinez/purescript-cookbook/builds/172322362#L339). I'm not entirely sure why...