### PR TITLE
fix %-buildProd target

### DIFF
--- a/makefile
+++ b/makefile
@@ -83,7 +83,10 @@ info:
 # ===== Makefile - Recipe-related Commands =====
 
 # Tests if recipe actually exists.
-recipes/%:
+# The unused dummy lowpriority prerequisite is just to allow
+# the rule for recipes/%/web/index.html to take priority over this rule.
+# https://stackoverflow.com/questions/62494658/gnu-make-not-matching-shortest-stem
+recipes/%: lowpriority%
 > @if [ ! -d $* ]
 > then
 >   echo
@@ -91,6 +94,10 @@ recipes/%:
 >   echo
 >   exit 1
 > fi
+
+# Does nothing. See above for explanation.
+lowpriority%:
+	@:
 
 # Variables shared across most targets
 recipes := $(shell ls recipes)
@@ -153,22 +160,19 @@ recipes/%/web:
 %-buildWeb: $(call recipeDir,%) $(call webDir,%) %-build
 > parcel build $(call webHtml,$*) --out-dir $(call webDistDir,$*) --no-minify --no-source-maps
 
-# Note: `%-buildProd` and its related commands were commented out
-# because the command doesn't currently work.
-
 # How to make prodDir
-# recipes/%/prod:
-# > mkdir -p $@
+recipes/%/prod:
+> mkdir -p $@
 
 # How to make prodHtml
-# recipes/%/prod/index.html: $(call prodDir,%)
-# > cp $(call webHtml,$*) $(call prodDir,$*)
+recipes/%/prod/index.html: $(call prodDir,%)
+> cp $(call webHtml,$*) $(call prodDir,$*)
 
 # Creates a minified production build.
 # For reference.
-# %-buildProd: $(call recipeDir,%) $(call webDir,%) $(call prodHtml,%)
-# > spago -x $(call recipeSpago,$*) bundle-app --main $(call main,$*) --to $(call prodJs,$*)
-# > parcel build $(call prodHtml,$*) --out-dir $(call prodDistDir,$*)
+%-buildProd: $(call recipeDir,%) $(call webDir,%) $(call prodHtml,%)
+> spago -x $(call recipeSpago,$*) bundle-app --main $(call main,$*) --to $(call prodJs,$*)
+> parcel build $(call prodHtml,$*) --out-dir $(call prodDistDir,$*)
 
 # ===== Makefile - CI Commands =====
 
@@ -214,4 +218,4 @@ testAllCommands:
 > $(MAKE) HelloWorld-build
 > $(MAKE) HelloWorld-buildWeb
 > $(MAKE) HelloWorld-testCI
-# > $(MAKE) HelloWorld-buildProd
+> $(MAKE) HelloWorld-buildProd


### PR DESCRIPTION
Fixes #64 

Interesting makefile behavior with this one.

Shortest stem takes priority... except when:
> a rule whose prerequisites actually exist or are mentioned always takes priority over a rule with prerequisites that must be made by chaining other implicit rules.

And **zero prerequisites** for `recipes/%:` is interpreted as prerequisites that "actually exist or are mentioned".