### PR TITLE
ReadPrintFileContents - show license instead of readme

### DIFF
--- a/recipes/ReadPrintFileContents/README.md
+++ b/recipes/ReadPrintFileContents/README.md
@@ -6,4 +6,4 @@ Reads a file's contents and prints it to the console.
 
 ### Node.js
 
-Since this is run from the root folder, it will print the repo's README.md, not this recipe's README.md file.
+Prints the contents of this repo's LICENSE file. Note that this recipe is run from the repo's root directory.

--- a/recipes/ReadPrintFileContents/src/Main.purs
+++ b/recipes/ReadPrintFileContents/src/Main.purs
@@ -11,5 +11,5 @@ import Node.FS.Aff (readTextFile)
 
 main :: Effect Unit
 main = launchAff_ do
-  fileContents <- readTextFile UTF8 "./README.md"
+  fileContents <- readTextFile UTF8 "./LICENSE"
   liftEffect $ log fileContents


### PR DESCRIPTION
One of the types of CI errors we'll encounter are readme diffs.

Printing a different file during this test helps with visual inspection of the CI logs.