### PR TITLE
Use useAff's result instead of synchronizing with separate state

### DIFF
--- a/recipes/BookReactHooks/src/Main.purs
+++ b/recipes/BookReactHooks/src/Main.purs
@@ -21,7 +21,6 @@ import Web.HTML.Window (document)
 
 data TextState
   = Failure
-  | Loading
   | Success String
 
 main :: Effect Unit
@@ -38,14 +37,13 @@ mkBookComponent = do
   let
     url = "https://elm-lang.org/assets/public-opinion.txt"
   component "Book" \_ -> React.do
-    (textState /\ setTextState) <- useState' Loading
-    useAff unit do
+    textState <- useAff unit do
       result <- Affjax.get ResponseFormat.string url
-      liftEffect case result of
+      pure case result of
         Right response
-          | response.status == StatusCode 200 -> setTextState (Success response.body)
-        _ -> setTextState Failure
+          | response.status == StatusCode 200 -> Just response.body
+        _ -> Failure
     pure case textState of
-      Failure -> R.text "I was unable to load your book."
-      Loading -> R.text "Loading..."
-      Success fullText -> R.pre_ [ R.text fullText ]
+      Nothing -> R.text "Loading..."
+      Just Failure -> R.text "I was unable to load your book."
+      Just (Success fullText) -> R.pre_ [ R.text fullText ]

--- a/recipes/BookReactHooks/src/Main.purs
+++ b/recipes/BookReactHooks/src/Main.purs
@@ -41,7 +41,7 @@ mkBookComponent = do
       result <- Affjax.get ResponseFormat.string url
       pure case result of
         Right response
-          | response.status == StatusCode 200 -> Just response.body
+          | response.status == StatusCode 200 -> Success response.body
         _ -> Failure
     pure case textState of
       Nothing -> R.text "Loading..."

--- a/recipes/BookReactHooks/src/Main.purs
+++ b/recipes/BookReactHooks/src/Main.purs
@@ -7,11 +7,10 @@ import Affjax.StatusCode (StatusCode(..))
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
 import Effect (Effect)
-import Effect.Class (liftEffect)
 import Effect.Exception (throw)
 import React.Basic.DOM (render)
 import React.Basic.DOM as R
-import React.Basic.Hooks (Component, component, useState', (/\))
+import React.Basic.Hooks (Component, component)
 import React.Basic.Hooks as React
 import React.Basic.Hooks.Aff (useAff)
 import Web.DOM.NonElementParentNode (getElementById)


### PR DESCRIPTION
This is a great resource, thanks for starting it!

I think for simple "fetch and display" tasks it's better to use `useAff`'s result directly rather than synchronizing it with a separate state. Do you prefer the separate state type? (this is mostly for my curiosity, with the PR just providing a diff to look at -- feel free to ignore/close).