### PR TITLE
Simplify ComponentsHalogenHooks

### DIFF
--- a/recipes/ComponentsHalogenHooks/src/Main.purs
+++ b/recipes/ComponentsHalogenHooks/src/Main.purs
@@ -1,6 +1,6 @@
 module ComponentsHalogenHooks.Main where
 
-import Prelude hiding (top)
+import Prelude
 
 import Data.Maybe (Maybe(..), maybe)
 import Data.Symbol (SProxy(..))
@@ -49,12 +49,11 @@ containerComponent = Hooks.component \rec _ -> Hooks.do
         ]
     ]
 
-data ButtonMessage = Toggled Boolean
 data ButtonQuery a = IsOn (Boolean -> a)
 
 buttonComponent
   :: forall unusedInput anyMonad
-   . H.Component HH.HTML ButtonQuery unusedInput ButtonMessage anyMonad
+   . H.Component HH.HTML ButtonQuery unusedInput Unit anyMonad
 buttonComponent = Hooks.component \rec _ -> Hooks.do
   enabled /\ enabledIdx <- Hooks.useState false
   Hooks.useQuery rec.queryToken case _ of
@@ -66,7 +65,7 @@ buttonComponent = Hooks.component \rec _ -> Hooks.do
     HH.button
       [ HP.title label
       , HE.onClick \_ -> Just do
-          newState <- Hooks.modify enabledIdx not
-          Hooks.raise rec.outputToken $ Toggled newState
+          _ <- Hooks.modify enabledIdx not
+          Hooks.raise rec.outputToken unit
       ]
       [ HH.text label ]


### PR DESCRIPTION
I was initially confused about how `ButtonMessage` was being used, and then realized that the component's output value is simply ignored by the parent when incrementing toggle count. So this can be replaced with `Unit`. Don't know whether this makes things more or less confusing. We could alternatively go with an `Output` alias and some more comments.