### PR TITLE
Bump `easy-purescript-nix`

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -5,8 +5,12 @@ let
     pkgs.fetchFromGitHub {
       owner = "justinwoo";
       repo = "easy-purescript-nix";
-      rev = "01ae1bc844a4eed1af7dfbbb202fdd297e3441b9";
-      sha256 = "0jx4xb202j43c504gzh27rp9f2571ywdw39dqp6qs76294zwlxkh";
+      # Latest `rev` and `sha256` can be obtained by using
+      # ```
+      # $ nix-prefetch-git https://github.com/justinwoo/easy-purescript-nix.git
+      # ```
+      rev = "c8c32741bc09e2ac0a94d5140cf51fa5de809e24";
+      sha256 = "0rn938nbxqsd7lp7l8z1y7bhzaq29vbziq6hq9llb3yh9xs10lmf";
     }
   ) {
     inherit pkgs;


### PR DESCRIPTION
`packages.dhall` specifies PureScript 0.13.8, while the `easy-purescript-nix` commit hash points to 0.13.6, so trying to build the project in `nix-shell` fails.

### Before
<img width="834" alt="Screen Shot 2021-01-18 at 1 36 19 AM" src="https://user-images.githubusercontent.com/26548438/104880576-cb0d9f00-592d-11eb-8881-8b9b73faa7ab.png">

### After
<img width="834" alt="Screen Shot 2021-01-18 at 1 37 39 AM" src="https://user-images.githubusercontent.com/26548438/104880562-c648eb00-592d-11eb-9864-7e3a5765f4e0.png">
