### PR TITLE
Fix DragAndDropReactHooks set hover to true in onDragOver

### DIFF
--- a/recipes/DragAndDropReactHooks/src/Main.purs
+++ b/recipes/DragAndDropReactHooks/src/Main.purs
@@ -68,7 +68,8 @@ mkApp = do
               Events.handler_ do
                 setHover false
           , onDragOver:
-              Events.handler DOM.Events.preventDefault mempty
+              Events.handler DOM.Events.preventDefault \_ -> do
+                setHover true
           , onDrop:
               Events.handler DOM.Events.preventDefault \e -> do
                 setHover false


### PR DESCRIPTION
I thought I could get away with just setting `hover` in `onDragEnter` and `onDragLeave`, but turns out [`onDragLeave` is triggered when cursor moves to a child element](https://stackoverflow.com/questions/7110353/html5-dragleave-fired-when-hovering-a-child-element).