### PR TITLE
chore: giphy cat api has updated, updating CatGifsReactHook to match

### DIFF
--- a/recipes/CatGifsReactHooks/src/Main.purs
+++ b/recipes/CatGifsReactHooks/src/Main.purs
@@ -73,4 +73,4 @@ getRandomCatGif = do
   pure do
     -- Using `hush` to ignore the possible error messages
     { body } <- hush response
-    hush (decodeJson body >>= (_ .: "data") >>= (_ .: "images") >>= (_ .: "fix_width_url"))
+    hush (decodeJson body >>= (_ .: "data") >>= (_ .: "images") >>= (_ .: "downsized") >>= (_ .: "url"))

--- a/recipes/CatGifsReactHooks/src/Main.purs
+++ b/recipes/CatGifsReactHooks/src/Main.purs
@@ -73,4 +73,4 @@ getRandomCatGif = do
   pure do
     -- Using `hush` to ignore the possible error messages
     { body } <- hush response
-    hush (decodeJson body >>= (_ .: "data") >>= (_ .: "image_url"))
+    hush (decodeJson body >>= (_ .: "data") >>= (_ .: "images") >>= (_ .: "fix_width_url"))


### PR DESCRIPTION
CatGifsReactHook was trying to extract a gif url that does not match the latest giphy respones. 
Updated the getRandomCatGif function to work with latest giphy API