### PR TITLE
Format repository with purs-tidy

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,3 +48,6 @@ jobs:
 
       - name: Run CI tests
         run: make testAllCI
+
+      - name: Check PureScript code is formatted
+        run: make formatCheck

--- a/.tidyrc.json
+++ b/.tidyrc.json
@@ -1,0 +1,10 @@
+{
+  "importSort": "ide",
+  "importWrap": "source",
+  "indent": 2,
+  "operatorsFile": null,
+  "ribbon": 1,
+  "typeArrowPlacement": "first",
+  "unicode": "never",
+  "width": null
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,7 @@ Follow these instructions for contributing new recipes. The Goal headers indicat
     1. Link to any other resources that a reader might find helpful. No need for detailed explanations of libraries here.
     1. List the `npm` dependencies your recipe uses (if any).
 1. Regenerate the table of recipes by running `make readme` while in the root folder
+1. Make sure the code is formatted consistently by running `make format`
 1. Submit a PR.
    - If this addresses a "Recipe Request" issue, the first line should read `Fixes #X` where `X` is the issue number.
 

--- a/broken/AffGameSnakeJs/src/Main.purs
+++ b/broken/AffGameSnakeJs/src/Main.purs
@@ -77,16 +77,15 @@ data Direction
 
 derive instance eqDirection :: Eq Direction
 
-type Snake
-  = NonEmptyArray Point
+type Snake = NonEmptyArray Point
 
 -- The type of our game state
-type Model
-  = { food :: Point
-    , snake :: Snake
-    , direction :: Direction
-    , genState :: GenState
-    }
+type Model =
+  { food :: Point
+  , snake :: Snake
+  , direction :: Direction
+  , genState :: GenState
+  }
 
 -- Some initial state values
 initialDirection :: Direction
@@ -206,8 +205,10 @@ render m = liftCanvasAction do
     -- `Vector2`s `ToRegion` instance:
     -- https://pursuit.purescript.org/packages/purescript-polymorphic-vectors/1.1.1/docs/Data.Vector.Polymorphic.Class#v:toRegionVector2
     fillRect
-      $  cellSizeNum * toNumber (xmax + 2)
-      >< cellSizeNum * toNumber (ymax + 2)
+      $ cellSizeNum
+          * toNumber (xmax + 2)
+              >< cellSizeNum
+          * toNumber (ymax + 2)
   -- Interior
   filled bgColor do
     fillRect $ makeRect
@@ -219,7 +220,6 @@ render m = liftCanvasAction do
   for_ m.snake (drawPoint snakeColor)
   -- Food
   drawPoint foodColor m.food
-
 
 -- AFFGAME
 --
@@ -261,31 +261,29 @@ game = mkAffGame
           , direction: initialDirection
           }
       pure
-        { env:       unit      :: Env
+        { env: unit :: Env
         -- We're using our `Model` type as the state of the game.
         , initState: initState :: Model
         }
   , updates:
-    -- We have a `keydown` update that updates the state with the direction we
-    -- pressed
-    [ keydown documentEventTarget do
-        mDir <- asksAt _keyboardEvent $ key >>> case _ of
-          "ArrowLeft"  -> Just Left
-          "ArrowUp"    -> Just Up
-          "ArrowRight" -> Just Right
-          "ArrowDown"  -> Just Down
-          _ -> Nothing
-        for_ mDir \dir -> modify (update (SetDir dir))
-    -- We also have an update that runs at our `ticksPerSecond` interval,
-    -- but approximated to the closest (future) animation frame. We simply
-    -- update the state, then read it again and render it to the canvas.
-    , animationFrameMatchInterval (pure $ FPS ticksPerSecond) do
-        modify (update Tick)
-        get >>= render
-    ]
+      -- We have a `keydown` update that updates the state with the direction we
+      -- pressed
+      [ keydown documentEventTarget do
+          mDir <- asksAt _keyboardEvent $ key >>> case _ of
+            "ArrowLeft" -> Just Left
+            "ArrowUp" -> Just Up
+            "ArrowRight" -> Just Right
+            "ArrowDown" -> Just Down
+            _ -> Nothing
+          for_ mDir \dir -> modify (update (SetDir dir))
+      -- We also have an update that runs at our `ticksPerSecond` interval,
+      -- but approximated to the closest (future) animation frame. We simply
+      -- update the state, then read it again and render it to the canvas.
+      , animationFrameMatchInterval (pure $ FPS ticksPerSecond) do
+          modify (update Tick)
+          get >>= render
+      ]
   }
-
-
 
 -- MAIN
 --

--- a/broken/DriverIoHalogenHooks/src/Main.purs
+++ b/broken/DriverIoHalogenHooks/src/Main.purs
@@ -25,12 +25,12 @@ main = HA.runHalogenAff do
     liftEffect $ log $ "Button was internally toggled to: " <> show newState
     pure Nothing
 
-  state0 ← io.query $ H.request IsOn
+  state0 <- io.query $ H.request IsOn
   liftEffect $ log $ "The button state is currently: " <> show state0
 
   void $ io.query $ H.tell (SetState true)
 
-  state1 ← io.query $ H.request IsOn
+  state1 <- io.query $ H.request IsOn
   liftEffect $ log $ "The button state is now: " <> show state1
 
 data ButtonQuery a

--- a/broken/DriverRoutingHalogenHooks/src/Main.purs
+++ b/broken/DriverRoutingHalogenHooks/src/Main.purs
@@ -5,8 +5,8 @@ import Prelude
 import Control.Coroutine as CR
 import Control.Coroutine.Aff (emit)
 import Control.Coroutine.Aff as CRA
-import Data.Foldable (traverse_)
 import Data.Array (snoc)
+import Data.Foldable (traverse_)
 import Data.Maybe (Maybe(..))
 import Data.String.CodeUnits as Str
 import Data.Tuple.Nested ((/\))
@@ -19,7 +19,7 @@ import Halogen.HTML as HH
 import Halogen.HTML.Properties as HP
 import Halogen.Hooks as Hooks
 import Halogen.VDom.Driver (runUI)
-import Web.Event.EventTarget (eventListener, addEventListener) as DOM
+import Web.Event.EventTarget (addEventListener, eventListener) as DOM
 import Web.HTML (window) as DOM
 import Web.HTML.Event.HashChangeEvent as HCE
 import Web.HTML.Event.HashChangeEvent.EventTypes as HCET
@@ -43,7 +43,7 @@ hashChangeProducer = CRA.produce \emitter -> do
   liftEffect $
     DOM.window
       >>= Window.toEventTarget
-      >>> DOM.addEventListener HCET.hashchange listener false
+        >>> DOM.addEventListener HCET.hashchange listener false
 
 -- A consumer coroutine that takes the `query` function from our component IO
 -- record and sends `ChangeRoute` queries in when it receives inputs from the
@@ -69,12 +69,12 @@ routeLogComponent = Hooks.component \rec _ -> Hooks.do
       pure $ Just next
   Hooks.pure $
     HH.div_
-    [ HH.p_ [ HH.text "Change the URL hash or choose an anchor link..." ]
-    , HH.ul_
-        [ HH.li_ [ HH.a [ HP.href "#link-a" ] [ HH.text "Link A" ] ]
-        , HH.li_ [ HH.a [ HP.href "#link-b" ] [ HH.text "Link B" ] ]
-        , HH.li_ [ HH.a [ HP.href "#link-c" ] [ HH.text "Link C" ] ]
-        ]
-    , HH.p_ [ HH.text "...to see it logged below:" ]
-    , HH.ol_ $ map (\msg -> HH.li_ [ HH.text msg ]) history
-    ]
+      [ HH.p_ [ HH.text "Change the URL hash or choose an anchor link..." ]
+      , HH.ul_
+          [ HH.li_ [ HH.a [ HP.href "#link-a" ] [ HH.text "Link A" ] ]
+          , HH.li_ [ HH.a [ HP.href "#link-b" ] [ HH.text "Link B" ] ]
+          , HH.li_ [ HH.a [ HP.href "#link-c" ] [ HH.text "Link C" ] ]
+          ]
+      , HH.p_ [ HH.text "...to see it logged below:" ]
+      , HH.ol_ $ map (\msg -> HH.li_ [ HH.text msg ]) history
+      ]

--- a/broken/HelloConcur/src/Main.purs
+++ b/broken/HelloConcur/src/Main.purs
@@ -1,9 +1,10 @@
 module HelloConcur.Main where
 
 import Prelude
-import Effect (Effect)
-import Concur.React.Run (runWidgetInDom)
+
 import Concur.React.DOM (text)
+import Concur.React.Run (runWidgetInDom)
+import Effect (Effect)
 
 main :: Effect Unit
 main = do

--- a/broken/MemoizeFibonacci/src/Main.purs
+++ b/broken/MemoizeFibonacci/src/Main.purs
@@ -1,6 +1,7 @@
 module MemoizeFibonacci.Main where
 
 import Prelude
+
 import Data.Function.Memoize (memoize)
 import Data.Interpolate (i)
 import Debug.Trace (spy)
@@ -13,15 +14,15 @@ main = do
   log $ i "fibFast result: " $ fibFast 7
   log $ i "fibSlow result: " $ fibSlow 7
 
-  -- The following variations type-check, but do not correctly memoize
-  -- the functions. They are commented out intentionally. Uncomment them
-  -- and run them to see for yourself.
-  -- log $ i "fibBroken1 result: " $ fibBroken1 7
-  -- log $ i "fibBroken2 result: " $ fibBroken2 7
-  -- log $ i "fibBroken3 result: " $ fibBroken3 7
+-- The following variations type-check, but do not correctly memoize
+-- the functions. They are commented out intentionally. Uncomment them
+-- and run them to see for yourself.
+-- log $ i "fibBroken1 result: " $ fibBroken1 7
+-- log $ i "fibBroken2 result: " $ fibBroken2 7
+-- log $ i "fibBroken3 result: " $ fibBroken3 7
 
-  -- Note: this one fails to compile.
-  -- log $ i "fibBroken4 result: " $ fibBroken4 7
+-- Note: this one fails to compile.
+-- log $ i "fibBroken4 result: " $ fibBroken4 7
 
 -- Basic fibonacci implementation
 fib :: Int -> Int
@@ -38,7 +39,7 @@ fibSlow 1 = spy "fibSlow 1" 1
 fibSlow n =
   spy ("fibSlow " <> show n)
     $ fibSlow (n - 2)
-    + fibSlow (n - 1)
+        + fibSlow (n - 1)
 
 --------------------------------------------------------------------------
 
@@ -49,7 +50,7 @@ fibFast 1 = spy "fibFast 1" 1
 fibFast n =
   spy ("fibFast " <> show n)
     $ fibMemo (n - 2)
-    + fibMemo (n - 1)
+        + fibMemo (n - 1)
 
 fibMemo :: Int -> Int
 fibMemo = memoize \n -> fibFast n
@@ -64,7 +65,7 @@ fibBroken1 1 = spy "fibBroken1 1" 1
 fibBroken1 n =
   spy ("fibBroken1 " <> show n)
     $ fibNonThunkedMemoize (n - 2)
-    + fibNonThunkedMemoize (n - 1)
+        + fibNonThunkedMemoize (n - 1)
 
 fibNonThunkedMemoize :: Int -> Int
 fibNonThunkedMemoize n = memoize fibBroken1 n
@@ -79,9 +80,10 @@ fibBroken2 1 = spy "fibBroken2 1" 1
 fibBroken2 n =
   let
     fibLetClauseMemoize = memoize \n -> fibBroken2 n
-  in spy ("fibBroken2 " <> show n)
-    $ fibLetClauseMemoize (n - 2)
-    + fibLetClauseMemoize (n - 1)
+  in
+    spy ("fibBroken2 " <> show n)
+      $ fibLetClauseMemoize (n - 2)
+          + fibLetClauseMemoize (n - 1)
 
 --------------------------------------------------------------------------
 
@@ -93,9 +95,9 @@ fibBroken3 1 = spy "fibBroken3 1" 1
 fibBroken3 n =
   spy ("fibBroken3 " <> show n)
     $ fibWhereClauseMemoize (n - 2)
-    + fibWhereClauseMemoize (n - 1)
+        + fibWhereClauseMemoize (n - 1)
   where
-    fibWhereClauseMemoize = memoize \n -> fibBroken3 n
+  fibWhereClauseMemoize = memoize \n -> fibBroken3 n
 
 --------------------------------------------------------------------------
 

--- a/broken/PayloadHttpApiNode/src/Main.purs
+++ b/broken/PayloadHttpApiNode/src/Main.purs
@@ -14,20 +14,20 @@ import Effect.Aff (Aff)
 import Effect.Aff.AVar as AffVar
 import Payload.ResponseTypes (Failure(..))
 import Payload.Server as Payload
-import Payload.Spec (GET, Spec(Spec), POST)
+import Payload.Spec (GET, POST, Spec(Spec))
 
 -- | This is used as a return type for whenever we don't have something
 -- | meaningful to return.
 type StatusCodeResponse =
-    { statusCode :: Int
-    , statusMessage :: String
-    }
+  { statusCode :: Int
+  , statusMessage :: String
+  }
 
 -- | Our API is all about quotes, and this is how we represent a single quote.
 type Quote =
-    { text :: String
-    , id :: Int
-    }
+  { text :: String
+  , id :: Int
+  }
 
 -- | This fully describes our API as a big record under the 'Spec' constructor.
 -- |
@@ -40,19 +40,22 @@ type Quote =
 -- | Note that the implementation is trivial: this only represents type-level
 -- | information used downstream.
 spec
-    :: Spec
-        { quote :: GET "/quote/<id>"
-            { params :: { id :: Int }
-            , response :: String
-            }
-        , addQuote :: POST "/quote"
-            { body :: String
-            , response :: StatusCodeResponse
-            }
-        , getAll :: GET "/quote"
-            { response :: Array Quote
-            }
-        }
+  :: Spec
+       { quote ::
+           GET "/quote/<id>"
+             { params :: { id :: Int }
+             , response :: String
+             }
+       , addQuote ::
+           POST "/quote"
+             { body :: String
+             , response :: StatusCodeResponse
+             }
+       , getAll ::
+           GET "/quote"
+             { response :: Array Quote
+             }
+       }
 spec = Spec
 
 -- | This is where everything comes together: we create a record of HANDLERS
@@ -68,17 +71,17 @@ spec = Spec
 -- | individual handler.
 handlers :: _
 handlers quotes =
-    { quote: quote quotes
-    , addQuote: addQuote quotes
-    , getAll: getAll quotes
-    }
+  { quote: quote quotes
+  , addQuote: addQuote quotes
+  , getAll: getAll quotes
+  }
 
 -- | Main entry point: we just create a new 'AVar' (fake "database") and
 -- | launch the payload server.
 main :: Effect Unit
 main = do
-    quotes <- EffVar.new $ Map.singleton 1 "This is a quote"
-    Payload.launch spec (handlers quotes)
+  quotes <- EffVar.new $ Map.singleton 1 "This is a quote"
+  Payload.launch spec (handlers quotes)
 
 -- | This represents our application's state. It's essentially our database
 -- | (except it gets reset when application gets restarted).
@@ -89,11 +92,11 @@ type State = AVar (Map Int String)
 -- | If we can't find the requested 'id', then we just return an error.
 -- | Otherwise, we return the requested quote.
 quote :: State -> { params :: { id :: Int } } -> Aff (Either Failure String)
-quote st { params : {id} } = do
-    quotes <- AffVar.read st
-    case Map.lookup id quotes of
-        Nothing -> pure $ Left $ Forward ""
-        Just v -> pure (pure v)
+quote st { params: { id } } = do
+  quotes <- AffVar.read st
+  case Map.lookup id quotes of
+    Nothing -> pure $ Left $ Forward ""
+    Just v -> pure (pure v)
 
 -- | Adding a quote requires us to 'block' reads/writes to our 'database', which
 -- | is precisely what 'take' does.
@@ -101,12 +104,12 @@ quote st { params : {id} } = do
 -- | We finish off by 'unblocking' and pushing our updated 'database'.
 addQuote :: State -> { body :: String } -> Aff StatusCodeResponse
 addQuote st { body } = do
-    quotes <- AffVar.take st
-    id <- case Map.findMax quotes of
-        Nothing -> pure 1
-        Just { key } -> pure (key + 1)
-    AffVar.put (Map.insert id body quotes) st
-    pure { statusCode: 200, statusMessage: body }
+  quotes <- AffVar.take st
+  id <- case Map.findMax quotes of
+    Nothing -> pure 1
+    Just { key } -> pure (key + 1)
+  AffVar.put (Map.insert id body quotes) st
+  pure { statusCode: 200, statusMessage: body }
 
 -- | We start by reading the current 'database'. Since we can't easily encode
 -- | a Map structure directly, we transform it to an Array by calling
@@ -116,9 +119,9 @@ addQuote st { body } = do
 -- | Array and change all Tuples to records.
 -- |
 -- | We end up returning all data in the 'database' as an array of records.
-getAll :: forall r. State -> { |r } -> Aff (Array Quote)
+getAll :: forall r. State -> { | r } -> Aff (Array Quote)
 getAll st _ = map tupleToRecord <<< Map.toUnfoldable <$> AffVar.read st
   where
-    tupleToRecord :: Tuple Int String -> Quote
-    tupleToRecord (Tuple id text) = {id, text}
+  tupleToRecord :: Tuple Int String -> Quote
+  tupleToRecord (Tuple id text) = { id, text }
 

--- a/broken/ReadPrintFileContentsConcur/src/Main.purs
+++ b/broken/ReadPrintFileContentsConcur/src/Main.purs
@@ -4,46 +4,52 @@ import Prelude
 
 import Concur.Core (Widget)
 import Concur.React (HTML)
-import Concur.React.DOM  as D
-import Concur.React.Props  as P
+import Concur.React.DOM as D
+import Concur.React.Props as P
 import Concur.React.Run (runWidgetInDom)
 import Data.Maybe (Maybe(..), maybe)
 import Effect (Effect)
 import Effect.Aff.Class (liftAff)
 import Effect.Class (liftEffect)
+import React.SyntheticEvent (NativeEventTarget, SyntheticEvent_, target)
+import Unsafe.Coerce (unsafeCoerce)
+import Web.Event.Internal.Types (EventTarget)
 import Web.File.File (toBlob)
 import Web.File.FileList (FileList, item)
 import Web.File.FileReader.Aff (readAsText)
 import Web.HTML.HTMLInputElement (files, fromEventTarget)
-import React.SyntheticEvent (target, SyntheticEvent_, NativeEventTarget)
-import Unsafe.Coerce (unsafeCoerce)
-import Web.Event.Internal.Types (EventTarget)
 
 fileList :: EventTarget -> Effect (Maybe FileList)
 fileList tar = case fromEventTarget tar of
   Just elem -> files elem
-  _         -> pure Nothing
+  _ -> pure Nothing
 
-getContent :: forall t
-  . Widget HTML (SyntheticEvent_ ( target :: NativeEventTarget
-                                 | t
-                                 )
-                ) -> Widget HTML String
+getContent
+  :: forall t
+   . Widget HTML
+       ( SyntheticEvent_
+           ( target :: NativeEventTarget
+           | t
+           )
+       )
+  -> Widget HTML String
 getContent ev = do
   nativeTarget <- liftEffect =<< target <$> ev
   mfs <- liftEffect $ fileList $ unsafeCoerce nativeTarget
-  liftAff $ maybe (pure "") 
-                       readAsText
-                       $ (Just <<< toBlob) =<< item 0 =<< mfs
+  liftAff
+    $ maybe (pure "")
+        readAsText
+    $ (Just <<< toBlob) =<< item 0 =<< mfs
 
-textFileToScreenWidget ∷ Widget HTML String
+textFileToScreenWidget :: Widget HTML String
 textFileToScreenWidget = do
-  content <- getContent $ D.input [ P._type "file"
-                                  , P.onChange
-                                  ]
-  D.pre' [D.text content]
-  
+  content <- getContent $ D.input
+    [ P._type "file"
+    , P.onChange
+    ]
+  D.pre' [ D.text content ]
+
 main :: Effect Unit
 main = do
-  runWidgetInDom "app" textFileToScreenWidget 
+  runWidgetInDom "app" textFileToScreenWidget
 

--- a/broken/RoutingHashHalogenClassic/src/Example.purs
+++ b/broken/RoutingHashHalogenClassic/src/Example.purs
@@ -1,18 +1,17 @@
 module RoutingHashHalogenClassic.Example where
 
 import Prelude
+
 import Data.Maybe (Maybe(..))
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Properties as HP
 import RoutingHashHalogenClassic.MyRouting (MyRoute)
 
-type State
-  = Maybe MyRoute
+type State = Maybe MyRoute
 
 -- Query must be (Type -> Type)
-data Query a
-  = Nav MyRoute a
+data Query a = Nav MyRoute a
 
 component :: forall i o m. H.Component Query i o m
 component =
@@ -39,7 +38,7 @@ render state =
       , renderLink "#posts/browse/2004/June" "Browse 2004 June"
       ]
 
-handleQuery ∷ forall a ac o m. Query a → H.HalogenM State ac () o m (Maybe a)
+handleQuery :: forall a ac o m. Query a -> H.HalogenM State ac () o m (Maybe a)
 handleQuery (Nav route a) = do
   H.put $ Just route
   pure (Just a)

--- a/broken/RoutingHashHalogenClassic/src/Main.purs
+++ b/broken/RoutingHashHalogenClassic/src/Main.purs
@@ -1,18 +1,19 @@
 module RoutingHashHalogenClassic.Main where
 
 import Prelude
+
 import Data.Maybe (Maybe(..))
 import Effect (Effect)
 import Effect.Aff (launchAff_)
 import Effect.Class (liftEffect)
 import Effect.Class.Console (log)
-import RoutingHashHalogenClassic.Example (Query(..))
-import RoutingHashHalogenClassic.Example as Example
 import Halogen as H
 import Halogen.Aff as HA
 import Halogen.VDom.Driver (runUI)
-import RoutingHashHalogenClassic.MyRouting (myRoute)
 import Routing.Hash (matches)
+import RoutingHashHalogenClassic.Example (Query(..))
+import RoutingHashHalogenClassic.Example as Example
+import RoutingHashHalogenClassic.MyRouting (myRoute)
 
 main :: Effect Unit
 main =

--- a/broken/RoutingHashHalogenClassic/src/Routing.purs
+++ b/broken/RoutingHashHalogenClassic/src/Routing.purs
@@ -1,13 +1,13 @@
 module RoutingHashHalogenClassic.MyRouting where
 
 import Prelude
+
 import Data.Foldable (oneOf)
 import Data.Generic.Rep (class Generic)
 import Data.Show.Generic (genericShow)
 import Routing.Match (Match, int, lit, str)
 
-type PostId
-  = Int
+type PostId = Int
 
 data MyRoute
   = PostIndex
@@ -24,8 +24,8 @@ myRoute :: Match MyRoute
 myRoute =
   lit "posts"
     *> oneOf
-        [ PostEdit <$> int <* lit "edit"
-        , Post <$> int
-        , PostBrowse <$> (lit "browse" *> int) <*> str
-        , pure PostIndex -- Unmatched goes to index too
-        ]
+      [ PostEdit <$> int <* lit "edit"
+      , Post <$> int
+      , PostBrowse <$> (lit "browse" *> int) <*> str
+      , pure PostIndex -- Unmatched goes to index too
+      ]

--- a/broken/RoutingPushHalogenClassic/src/Example.purs
+++ b/broken/RoutingPushHalogenClassic/src/Example.purs
@@ -1,18 +1,17 @@
 module RoutingPushHalogenClassic.Example where
 
 import Prelude
+
 import Data.Maybe (Maybe(..))
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Properties as HP
 import RoutingPushHalogenClassic.MyRouting (MyRoute)
 
-type State
-  = Maybe MyRoute
+type State = Maybe MyRoute
 
 -- Query must be (Type -> Type)
-data Query a
-  = Nav MyRoute a
+data Query a = Nav MyRoute a
 
 component :: forall i o m. H.Component Query i o m
 component =
@@ -40,7 +39,7 @@ render state =
       , renderLink "/posts/?b=2&a=1" "Set 'a' and 'b' query parameters"
       ]
 
-handleQuery ∷ forall a ac o m. Query a → H.HalogenM State ac () o m (Maybe a)
+handleQuery :: forall a ac o m. Query a -> H.HalogenM State ac () o m (Maybe a)
 handleQuery (Nav route a) = do
   H.put $ Just route
   pure (Just a)

--- a/broken/RoutingPushHalogenClassic/src/Main.purs
+++ b/broken/RoutingPushHalogenClassic/src/Main.purs
@@ -1,18 +1,19 @@
 module RoutingPushHalogenClassic.Main where
 
 import Prelude
+
 import Data.Maybe (Maybe(..))
 import Effect (Effect)
 import Effect.Aff (launchAff_)
 import Effect.Class (liftEffect)
 import Effect.Class.Console (log)
-import RoutingPushHalogenClassic.Example (Query(..))
-import RoutingPushHalogenClassic.Example as Example
 import Halogen as H
 import Halogen.Aff as HA
 import Halogen.VDom.Driver (runUI)
-import RoutingPushHalogenClassic.MyRouting (myRoute)
 import Routing.PushState (makeInterface, matches)
+import RoutingPushHalogenClassic.Example (Query(..))
+import RoutingPushHalogenClassic.Example as Example
+import RoutingPushHalogenClassic.MyRouting (myRoute)
 
 main :: Effect Unit
 main =

--- a/broken/RoutingPushHalogenClassic/src/Routing.purs
+++ b/broken/RoutingPushHalogenClassic/src/Routing.purs
@@ -1,13 +1,13 @@
 module RoutingPushHalogenClassic.MyRouting where
 
 import Prelude
+
 import Data.Foldable (oneOf)
 import Data.Generic.Rep (class Generic)
 import Data.Show.Generic (genericShow)
 import Routing.Match (Match, int, lit, param, root, str)
 
-type PostId
-  = Int
+type PostId = Int
 
 data MyRoute
   = PostIndex
@@ -25,9 +25,9 @@ myRoute :: Match MyRoute
 myRoute =
   root *> lit "posts"
     *> oneOf
-        [ PostEdit <$> int <* lit "edit"
-        , Post <$> int
-        , PostBrowse <$> (lit "browse" *> int) <*> str
-        , ParamsAB <$> (param "a") <*> (param "b")
-        , pure PostIndex -- Unmatched goes to index too
-        ]
+      [ PostEdit <$> int <* lit "edit"
+      , Post <$> int
+      , PostBrowse <$> (lit "browse" *> int) <*> str
+      , ParamsAB <$> (param "a") <*> (param "b")
+      , pure PostIndex -- Unmatched goes to index too
+      ]

--- a/broken/TimeHalogenHooks/src/Main.purs
+++ b/broken/TimeHalogenHooks/src/Main.purs
@@ -53,12 +53,12 @@ hookComponent = Hooks.component \_ _ -> Hooks.do
       Hooks.unsubscribe subId
 
   Hooks.pure $
-    HH.h1_ [ HH.text $ i hour":"minute":"second ]
+    HH.h1_ [ HH.text $ i hour ":" minute ":" second ]
 
   where
-    getTime = liftEffect do
-      now <- JSDate.now
-      hour <- floor <$> JSDate.getHours now
-      minute <- floor <$> JSDate.getMinutes now
-      second <- floor <$> JSDate.getSeconds now
-      pure { hour, minute, second }
+  getTime = liftEffect do
+    now <- JSDate.now
+    hour <- floor <$> JSDate.getHours now
+    minute <- floor <$> JSDate.getMinutes now
+    second <- floor <$> JSDate.getSeconds now
+    pure { hour, minute, second }

--- a/makefile
+++ b/makefile
@@ -97,6 +97,16 @@ installDeps:
 > npm i
 > rm package-lock.json
 
+# Format PureScript code
+.PHONY: format
+format:
+> npx purs-tidy format-in-place recipes broken
+
+# Check PureScript code is formatted
+.PHONY: formatCheck
+formatCheck:
+> npx purs-tidy check recipes broken
+
 # ===== Makefile - Recipe-related Commands =====
 
 # Tests if recipe actually exists.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "parcel": "^2.6.2",
     "process": "^0.11.10",
     "purescript": "^0.15.4",
+    "purs-tidy": "^0.9.1",
     "spago": "^0.20.9"
   },
   "dependencies": {

--- a/recipes/AddRemoveEventListenerJs/src/Main.purs
+++ b/recipes/AddRemoveEventListenerJs/src/Main.purs
@@ -10,7 +10,7 @@ import Effect.Ref as Ref
 import Unsafe.Coerce (unsafeCoerce)
 import Web.DOM.Element as Element
 import Web.DOM.ParentNode (QuerySelector(..), querySelector)
-import Web.Event.Event (EventType, Event)
+import Web.Event.Event (Event, EventType)
 import Web.Event.EventTarget (EventTarget, addEventListener, eventListener, removeEventListener)
 import Web.HTML (window)
 import Web.HTML.HTMLDocument as Document
@@ -34,11 +34,11 @@ main = do
   case mbButtonAddEL, mbButtonRemoveEL, mbButtonMain, mbButtonRemove2nd of
     Just bAddEL, Just bRemoveEL, Just bMain, Just bRemove2nd -> do
       let
-      -- make it possible to add event listeners to these elements
-      -- by changing their types from `Element` to `EventTarget`
-        buttonAddEL     = Element.toEventTarget bAddEL
-        buttonRemoveEL  = Element.toEventTarget bRemoveEL
-        buttonMain      = Element.toEventTarget bMain
+        -- make it possible to add event listeners to these elements
+        -- by changing their types from `Element` to `EventTarget`
+        buttonAddEL = Element.toEventTarget bAddEL
+        buttonRemoveEL = Element.toEventTarget bRemoveEL
+        buttonMain = Element.toEventTarget bMain
         buttonRemove2nd = Element.toEventTarget bRemove2nd
 
       -- In this first approach, we will add an event listener,
@@ -86,8 +86,9 @@ main = do
       -- where we don't need to store a reference to the listener since
       -- it is still in scope.
       removeListener <- addBetterListener METypes.click false buttonMain \_ -> do
-        log $ "Better listener: this is a better way to add/remove \
-              \an event listener."
+        log $
+          "Better listener: this is a better way to add/remove \
+          \an event listener."
 
       remove2ndApproachListener <- eventListener \_ -> do
         log "Now removing event listener using better approach"
@@ -95,8 +96,9 @@ main = do
       addEventListener METypes.click remove2ndApproachListener false buttonRemove2nd
 
     _, _, _, _ -> do
-      log $ "Could not get all three buttons. Please open an issue for this \
-            \recipe on the PureScript cookbook."
+      log $
+        "Could not get all three buttons. Please open an issue for this \
+        \recipe on the PureScript cookbook."
 
 printMessage :: Event -> Effect Unit
 printMessage e = do
@@ -104,8 +106,10 @@ printMessage e = do
     mouseEvent :: MouseEvent
     mouseEvent = unsafeCoerce e
   log "Triggered a mouse click event handler."
-  log $ i "Screen X: "(show (screenX mouseEvent))"\n\
-          \Screen Y: "(show (screenY mouseEvent))
+  log $ i "Screen X: " (show (screenX mouseEvent))
+    "\n\
+    \Screen Y: "
+    (show (screenY mouseEvent))
 
 -- | Intended usage:
 -- | ```
@@ -117,7 +121,11 @@ printMessage e = do
 -- | ```
 addBetterListener
   :: forall a
-   . EventType -> Boolean -> EventTarget -> (Event -> Effect a) -> Effect (Effect Unit)
+   . EventType
+  -> Boolean
+  -> EventTarget
+  -> (Event -> Effect a)
+  -> Effect (Effect Unit)
 addBetterListener type_ useCaptureRatherThanBubble target listener = do
   evListener <- eventListener listener
   addEventListener type_ evListener useCaptureRatherThanBubble target

--- a/recipes/AffjaxPostNode/src/Main.purs
+++ b/recipes/AffjaxPostNode/src/Main.purs
@@ -16,11 +16,12 @@ import Prelude (Unit, bind, show, ($), (<>))
 -- expected response: (at least if `http://jsonplaceholder.typicode.com/posts` is available to you)
 -- POST http://jsonplaceholder.typicode.com/posts response: (Right { body: "body", id: (Just 101), title: "title", userId: 22 })
 
-type Post = { id     :: Maybe Int
-            , title  :: String
-            , body   :: String
-            , userId :: Int
-            }
+type Post =
+  { id :: Maybe Int
+  , title :: String
+  , body :: String
+  , userId :: Int
+  }
 
 postToJson :: Post -> Json
 postToJson = encodeJson
@@ -30,22 +31,25 @@ jsonToPost = decodeJson
 
 main :: Effect Unit
 main = launchAff_ $ do
-  let 
+  let
     postdata :: Post
-    postdata =  { id    : Nothing -- note how this returns filled-in if service works
-                , title : "title"
-                , body  : "body"
-                , userId: 22 }
+    postdata =
+      { id: Nothing -- note how this returns filled-in if service works
+      , title: "title"
+      , body: "body"
+      , userId: 22
+      }
 
     endpoint :: String
     endpoint = "http://jsonplaceholder.typicode.com/posts"
-    
+
   result <- AX.post ResponseFormat.json endpoint (Just $ json $ postToJson postdata)
   case result of
 
-    Left err -> 
+    Left err ->
       log $ "POST " <> endpoint <> " response failed to decode: " <> AX.printError err
 
     Right response -> do
       log $ "POST " <> endpoint <> " response: " <> J.stringify response.body
-         <> "\n>>> " <> show (jsonToPost response.body)
+        <> "\n>>> "
+        <> show (jsonToPost response.body)

--- a/recipes/BookHalogenHooks/src/Main.purs
+++ b/recipes/BookHalogenHooks/src/Main.purs
@@ -2,9 +2,9 @@ module BookHalogenHooks.Main where
 
 import Prelude
 
-import Affjax.Web as AX
 import Affjax.ResponseFormat as AXRF
 import Affjax.StatusCode (StatusCode(..))
+import Affjax.Web as AX
 import Data.Either (Either(..))
 import Data.HTTP.Method (Method(..))
 import Data.Maybe (Maybe(..))

--- a/recipes/BookReactHooks/src/Main.purs
+++ b/recipes/BookReactHooks/src/Main.purs
@@ -1,9 +1,10 @@
 module BookReactHooks.Main where
 
 import Prelude
-import Affjax.Web as Affjax
+
 import Affjax.ResponseFormat as ResponseFormat
 import Affjax.StatusCode (StatusCode(..))
+import Affjax.Web as Affjax
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
 import Effect (Effect)

--- a/recipes/ButtonsHalogenHooks/src/Main.purs
+++ b/recipes/ButtonsHalogenHooks/src/Main.purs
@@ -3,6 +3,7 @@ module ButtonsHalogenHooks.Main where
 import Prelude
 
 import Data.Maybe (Maybe(..))
+import Data.Tuple.Nested ((/\))
 import Effect (Effect)
 import Halogen as H
 import Halogen.Aff as HA
@@ -10,7 +11,6 @@ import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
 import Halogen.Hooks as Hooks
 import Halogen.VDom.Driver (runUI)
-import Data.Tuple.Nested ((/\))
 
 main :: Effect Unit
 main =
@@ -26,10 +26,10 @@ hookComponent = Hooks.component \_ _ -> Hooks.do
   Hooks.pure $
     HH.div_
       [ HH.button
-        [ HE.onClick \_ -> Hooks.modify_ countIdx (_ - 1) ]
-        [ HH.text "-" ]
+          [ HE.onClick \_ -> Hooks.modify_ countIdx (_ - 1) ]
+          [ HH.text "-" ]
       , HH.div_ [ HH.text $ show count ]
       , HH.button
-        [ HE.onClick \_ -> Hooks.modify_ countIdx (_ + 1) ]
-        [ HH.text "+" ]
+          [ HE.onClick \_ -> Hooks.modify_ countIdx (_ + 1) ]
+          [ HH.text "+" ]
       ]

--- a/recipes/ButtonsReactHooks/src/Main.purs
+++ b/recipes/ButtonsReactHooks/src/Main.purs
@@ -1,6 +1,7 @@
 module ButtonsReactHooks.Main where
 
 import Prelude
+
 import Data.Maybe (Maybe(..))
 import Effect (Effect)
 import Effect.Exception (throw)

--- a/recipes/CapabilityPatternNode/src/Application.purs
+++ b/recipes/CapabilityPatternNode/src/Application.purs
@@ -8,19 +8,20 @@ import Prelude (class Monad, Unit, bind, discard, pure, ($), (<>))
 
 -- | Monads to define each capability required by the program
 class (Monad m) <= Logger m where
-    log :: String -> m Unit
+  log :: String -> m Unit
 
 class (Monad m) <= GetUserName m where
-    getUserName :: m Name
+  getUserName :: m Name
 
 -- | a program that will run in _any_ monad that can fulfill the
 -- | requirements (Logger and GetUserName)
-program :: forall m.
-    Logger m =>
-    GetUserName m =>
-    m String
+program
+  :: forall m
+   . Logger m
+  => GetUserName m
+  => m String
 program = do
-    log "what is your name?"
-    name <- getUserName
-    log $ "Your name is " <> getName name
-    pure $ getName name
+  log "what is your name?"
+  name <- getUserName
+  log $ "Your name is " <> getName name
+  pure $ getName name

--- a/recipes/CapabilityPatternNode/src/Main.purs
+++ b/recipes/CapabilityPatternNode/src/Main.purs
@@ -2,16 +2,15 @@ module CapabilityPatternNode.Main where
 
 import Prelude
 
-import App.Production.Sync (runApp, Environment) as Sync
-import App.Production.Async (runApp, Environment) as Async
-import App.Test (runApp, Environment) as Test
 import App.Application (program)
+import App.Production.Async (Environment, runApp) as Async
+import App.Production.Sync (Environment, runApp) as Sync
+import App.Test (Environment, runApp) as Test
 import Effect (Effect)
 import Effect.Aff (launchAff_)
 import Effect.Class (liftEffect)
 import Effect.Class.Console (log)
 import Test.Assert (assert)
-
 
 -- | Layer 0 - Running the `program` in three different contexts
 main :: Effect Unit
@@ -23,8 +22,6 @@ main = launchAff_ do
   liftEffect $ mainTest { testEnv: "Test" }
   pure unit
 
-
-
 -- Three different "main" functions for three different scenarios
 mainSync :: Sync.Environment -> Effect Unit
 mainSync env = do
@@ -35,7 +32,8 @@ mainTest :: Test.Environment -> Effect Unit
 mainTest env = do
   assert $ (Test.runApp program env) == "succeeds"
   log "first test succeeded, now a failing test which will crash"
-  -- assert $ (Test.runApp program env) == "failing test"
+
+-- assert $ (Test.runApp program env) == "failing test"
 
 mainAff1 :: Async.Environment -> Effect Unit
 mainAff1 env = launchAff_ do

--- a/recipes/CapabilityPatternNode/src/ProductionAsync.purs
+++ b/recipes/CapabilityPatternNode/src/ProductionAsync.purs
@@ -1,10 +1,11 @@
 module App.Production.Async where
+
 -- Layers One and Two have to be in same file due to orphan instance restriction
 
 import Prelude
 
+import App.Application (class GetUserName, class Logger)
 import App.Types (Name(..))
-import App.Application (class Logger, class GetUserName)
 import Control.Monad.Reader (class MonadAsk, ReaderT, ask, asks, runReaderT)
 import Effect.Aff (Aff, Milliseconds(..), delay)
 import Effect.Aff.Class (class MonadAff, liftAff)
@@ -23,13 +24,13 @@ runApp :: forall a. AppMA a -> Environment -> Aff a
 runApp (AppMA reader_T) env = runReaderT reader_T env
 
 -- | Layer 1 Production in Aff
-derive newtype instance functorAppMA     :: Functor AppMA
-derive newtype instance applyAppMA       :: Apply AppMA
+derive newtype instance functorAppMA :: Functor AppMA
+derive newtype instance applyAppMA :: Apply AppMA
 derive newtype instance applicativeAppMA :: Applicative AppMA
-derive newtype instance bindAppMA        :: Bind AppMA
-derive newtype instance monadAppMA       :: Monad AppMA
+derive newtype instance bindAppMA :: Bind AppMA
+derive newtype instance monadAppMA :: Monad AppMA
 derive newtype instance monadEffectAppMA :: MonadEffect AppMA
-derive newtype instance monadAffAppMA    :: MonadAff AppMA
+derive newtype instance monadAffAppMA :: MonadAff AppMA
 
 -- | Reader instance not quite as simple a derivation as "derive newtype",
 -- | as it needs TypeEquals for the env

--- a/recipes/CapabilityPatternNode/src/ProductionSync.purs
+++ b/recipes/CapabilityPatternNode/src/ProductionSync.purs
@@ -1,10 +1,11 @@
 module App.Production.Sync where
+
 -- Layers One and Two have to be in same file due to orphan instance restriction
 
 import Prelude
 
+import App.Application (class GetUserName, class Logger)
 import App.Types (Name(..))
-import App.Application (class Logger, class GetUserName)
 import Control.Monad.Reader (class MonadAsk, ReaderT, ask, asks, runReaderT)
 import Effect (Effect)
 import Effect.Class (class MonadEffect, liftEffect)
@@ -21,15 +22,14 @@ newtype AppM a = AppM (ReaderT Environment Effect a)
 runApp :: forall a. AppM a -> Environment -> Effect a
 runApp (AppM reader_T) env = runReaderT reader_T env
 
-
 -- | Layer 1 Provide instances for all capabilities needed
 -- | Many of the instances are provided by deriving from the 
 -- | underlying ReaderT...
-derive newtype instance functorAppM     :: Functor AppM
-derive newtype instance applyAppM       :: Apply AppM
+derive newtype instance functorAppM :: Functor AppM
+derive newtype instance applyAppM :: Apply AppM
 derive newtype instance applicativeAppM :: Applicative AppM
-derive newtype instance bindAppM        :: Bind AppM
-derive newtype instance monadAppM       :: Monad AppM
+derive newtype instance bindAppM :: Bind AppM
+derive newtype instance monadAppM :: Monad AppM
 derive newtype instance monadEffectAppM :: MonadEffect AppM
 
 -- | Reader instance not quite as simple a derivation as "derive newtype",

--- a/recipes/CapabilityPatternNode/src/Test.purs
+++ b/recipes/CapabilityPatternNode/src/Test.purs
@@ -1,10 +1,11 @@
 module App.Test where
+
 -- Layers 1 & 2 must be in same module due to orphan instance restriction
 
 import Prelude
 
+import App.Application (class GetUserName, class Logger)
 import App.Types (Name(..))
-import App.Application (class Logger, class GetUserName)
 import Control.Monad.Reader (Reader, runReader)
 
 -- | Layer 2 Define our "Test" Monad...
@@ -19,11 +20,11 @@ runApp (TestM reader) env = runReader reader env
 -- | Layer 1 Provide instances for all capabilities needed
 -- | Many of the instances are provided by deriving from the 
 -- | underlying Reader...
-derive newtype instance functorTestM     :: Functor TestM
-derive newtype instance applyTestM       :: Apply TestM
+derive newtype instance functorTestM :: Functor TestM
+derive newtype instance applyTestM :: Apply TestM
 derive newtype instance applicativeTestM :: Applicative TestM
-derive newtype instance bindTestM        :: Bind TestM
-derive newtype instance monadTestM       :: Monad TestM
+derive newtype instance bindTestM :: Bind TestM
+derive newtype instance monadTestM :: Monad TestM
 
 -- | Test doesn't have access to Effect so can't log to console
 instance loggerTestM :: Logger TestM where

--- a/recipes/CapabilityPatternNode/src/Types.purs
+++ b/recipes/CapabilityPatternNode/src/Types.purs
@@ -7,7 +7,6 @@ newtype Name = Name String
 getName :: Name -> String
 getName (Name s) = s
 
-
 -- NB this is the smallest file in this skeletal example
 -- but if you can you'd like to have as much of your code
 -- as you possibly can in this Layer!!

--- a/recipes/CardsHalogenHooks/src/Main.purs
+++ b/recipes/CardsHalogenHooks/src/Main.purs
@@ -1,7 +1,8 @@
 module CardsHalogenHooks.Main where
 
 import Prelude
-import CSS (fontSize, em)
+
+import CSS (em, fontSize)
 import Data.Array.NonEmpty (cons')
 import Data.Maybe (Maybe(..))
 import Data.Tuple.Nested ((/\))
@@ -35,19 +36,19 @@ hookComponent = Hooks.component \_ _ -> Hooks.do
   (card /\ _) /\ cardStateIdx <- Hooks.useState (runGen cardGenerator initialGenState)
   Hooks.pure $
     HH.div_
-    [ HH.button
-      [ HE.onClick \_ -> do
-        -- Modify the card generator state by re-running the generator.
-        -- We don't need the card value for this update function, so it is ignored with `_`.
-        Hooks.modify_ cardStateIdx \(_ /\ genState) -> runGen cardGenerator genState
+      [ HH.button
+          [ HE.onClick \_ -> do
+              -- Modify the card generator state by re-running the generator.
+              -- We don't need the card value for this update function, so it is ignored with `_`.
+              Hooks.modify_ cardStateIdx \(_ /\ genState) -> runGen cardGenerator genState
+          ]
+          [ HH.text "Draw" ]
+      , HH.div
+          [ HC.style do
+              fontSize $ em 12.0
+          ]
+          [ HH.text $ viewCard card ]
       ]
-      [ HH.text "Draw" ]
-    , HH.div
-      [ HC.style do
-        fontSize $ em 12.0
-      ]
-      [ HH.text $ viewCard card ]
-    ]
 
 data Card
   = Ace

--- a/recipes/CardsReactHooks/src/Main.purs
+++ b/recipes/CardsReactHooks/src/Main.purs
@@ -1,6 +1,7 @@
 module CardsReactHooks.Main where
 
 import Prelude
+
 import Data.Array.NonEmpty (cons')
 import Data.Maybe (Maybe(..))
 import Effect (Effect)

--- a/recipes/CatGifsHalogenHooks/src/Main.purs
+++ b/recipes/CatGifsHalogenHooks/src/Main.purs
@@ -2,9 +2,9 @@ module CatGifsHalogenHooks.Main where
 
 import Prelude
 
-import Affjax.Web as AX
 import Affjax.ResponseFormat as AXRF
 import Affjax.StatusCode (StatusCode(..))
+import Affjax.Web as AX
 import CSS (block, display)
 import Data.Argonaut.Core (Json)
 import Data.Codec (decode)
@@ -75,29 +75,30 @@ hookComponent = Hooks.component \_ _ -> Hooks.do
             HH.div_
               [ HH.text "I could not load a random cat for some reason. "
               , HH.button
-                [ HE.onClick \_ -> getNextGif
-                ]
-                [ HH.text "Try Again!" ]
+                  [ HE.onClick \_ -> getNextGif
+                  ]
+                  [ HH.text "Try Again!" ]
               ]
 
           RD.Success url ->
             HH.div_
               [ HH.button
-                [ HE.onClick \_ -> getNextGif
-                , HC.style $ display block
-                ]
-                [ HH.text "More Please!" ]
+                  [ HE.onClick \_ -> getNextGif
+                  , HC.style $ display block
+                  ]
+                  [ HH.text "More Please!" ]
               , HH.img [ HP.src url ]
               ]
       ]
 
 decodeJson :: Json -> Either JsonDecodeError { data :: { images :: { downsized :: { url :: String } } } }
-decodeJson = decode $
-  CA.object "data" $ CAR.record
-    { data: CA.object "images" $ CAR.record
-        { images: CA.object "downsized" $ CAR.record
-            { downsized: CA.object "url" $ CAR.record
-                { url: CA.string }
-            }
-        }
-    }
+decodeJson = decode
+  $ CA.object "data"
+  $ CAR.record
+      { data: CA.object "images" $ CAR.record
+          { images: CA.object "downsized" $ CAR.record
+              { downsized: CA.object "url" $ CAR.record
+                  { url: CA.string }
+              }
+          }
+      }

--- a/recipes/CatGifsReactHooks/src/Main.purs
+++ b/recipes/CatGifsReactHooks/src/Main.purs
@@ -1,8 +1,9 @@
 module CatGifsReactHooks.Main where
 
 import Prelude
-import Affjax.Web as Affjax
+
 import Affjax.ResponseFormat as ResponseFormat
+import Affjax.Web as Affjax
 import Data.Argonaut.Decode (decodeJson)
 import Data.Argonaut.Decode.Combinators ((.:))
 import Data.Either (hush)

--- a/recipes/ClockReactHooks/src/Main.purs
+++ b/recipes/ClockReactHooks/src/Main.purs
@@ -19,8 +19,7 @@ import Web.HTML.HTMLDocument (body)
 import Web.HTML.HTMLElement (toElement)
 import Web.HTML.Window (document)
 
-type Time
-  = { hours :: Number, minutes :: Number, seconds :: Number }
+type Time = { hours :: Number, minutes :: Number, seconds :: Number }
 
 main :: Effect Unit
 main = do
@@ -68,8 +67,7 @@ hand width length turns =
       , strokeLinecap: "round"
       }
 
-newtype UseCurrentTime hooks
-  = UseCurrentTime (UseEffect Unit (UseState Time hooks))
+newtype UseCurrentTime hooks = UseCurrentTime (UseEffect Unit (UseState Time hooks))
 
 derive instance ntUseCurrentTime :: Newtype (UseCurrentTime hooks) _
 

--- a/recipes/ComponentsHalogenHooks/src/Main.purs
+++ b/recipes/ComponentsHalogenHooks/src/Main.purs
@@ -37,25 +37,25 @@ containerComponent = Hooks.component \rec _ -> Hooks.do
   buttonState /\ buttonStateIdx <- Hooks.useState (Nothing :: Maybe Boolean)
   Hooks.pure $
     HH.div_
-    [ HH.slot _button unit buttonComponent unit \_ -> do
-        Hooks.modify_ toggleCountIdx (_ + 1)
-    , HH.p_
-        [ HH.text ("Button has been toggled " <> show toggleCount <> " time(s)") ]
-    , HH.p_
-        [ HH.text
-            $ "Last time I checked, the button was: "
-            <> (maybe "(not checked yet)" (if _ then "on" else "off") buttonState)
-            <> ". "
-        , HH.button
-            [ HE.onClick \_ -> do
-                mbBtnState <- Hooks.query rec.slotToken _button unit $ H.mkRequest IsOn
-                Hooks.put buttonStateIdx mbBtnState
-            ]
-            [ HH.text "Check now" ]
-        ]
-    , HH.p_
-        [ HH.text ("Parent has been rendered " <> show parentRenders <> " time(s)") ]
-    ]
+      [ HH.slot _button unit buttonComponent unit \_ -> do
+          Hooks.modify_ toggleCountIdx (_ + 1)
+      , HH.p_
+          [ HH.text ("Button has been toggled " <> show toggleCount <> " time(s)") ]
+      , HH.p_
+          [ HH.text
+              $ "Last time I checked, the button was: "
+                  <> (maybe "(not checked yet)" (if _ then "on" else "off") buttonState)
+                  <> ". "
+          , HH.button
+              [ HE.onClick \_ -> do
+                  mbBtnState <- Hooks.query rec.slotToken _button unit $ H.mkRequest IsOn
+                  Hooks.put buttonStateIdx mbBtnState
+              ]
+              [ HH.text "Check now" ]
+          ]
+      , HH.p_
+          [ HH.text ("Parent has been rendered " <> show parentRenders <> " time(s)") ]
+      ]
 
 data ButtonMessage = Toggled Boolean
 data ButtonQuery a = IsOn (Boolean -> a)

--- a/recipes/ComponentsInputHalogenHooks/src/Main.purs
+++ b/recipes/ComponentsInputHalogenHooks/src/Main.purs
@@ -33,22 +33,22 @@ containerComponent = Hooks.component \_ _ -> Hooks.do
   state /\ stateIdx <- Hooks.useState 0
   Hooks.pure $
     HH.div_
-    [ HH.ul_
-        [ HH.slot _display 1 displayComponent state absurd
-        , HH.slot _display 2 displayComponent (state * 2) absurd
-        , HH.slot _display 3 displayComponent (state * 3) absurd
-        , HH.slot _display 4 displayComponent (state * 10) absurd
-        , HH.slot _display 5 displayComponent (state * state) absurd
-        ]
-    , HH.button
-        [ HE.onClick \_ -> Hooks.modify_ stateIdx (_ + 1) ]
-        [ HH.text "+1"]
-    , HH.button
-        [ HE.onClick \_ -> Hooks.modify_ stateIdx (_ - 1) ]
-        [ HH.text "-1"]
-    , HH.p_
-        [ HH.text ("Parent has been rendered " <> show parentRenders <> " time(s)") ]
-    ]
+      [ HH.ul_
+          [ HH.slot _display 1 displayComponent state absurd
+          , HH.slot _display 2 displayComponent (state * 2) absurd
+          , HH.slot _display 3 displayComponent (state * 3) absurd
+          , HH.slot _display 4 displayComponent (state * 10) absurd
+          , HH.slot _display 5 displayComponent (state * state) absurd
+          ]
+      , HH.button
+          [ HE.onClick \_ -> Hooks.modify_ stateIdx (_ + 1) ]
+          [ HH.text "+1" ]
+      , HH.button
+          [ HE.onClick \_ -> Hooks.modify_ stateIdx (_ - 1) ]
+          [ HH.text "-1" ]
+      , HH.p_
+          [ HH.text ("Parent has been rendered " <> show parentRenders <> " time(s)") ]
+      ]
 
 _display = Proxy :: Proxy "display"
 
@@ -59,9 +59,9 @@ displayComponent
 displayComponent = Hooks.component \_ input -> Hooks.do
   Hooks.pure $
     HH.div_
-    [ HH.text "My input value is:"
-    , HH.strong_ [ HH.text (show input) ]
-    ]
+      [ HH.text "My input value is:"
+      , HH.strong_ [ HH.text (show input) ]
+      ]
 
 useRenderCount
   :: forall m a

--- a/recipes/ComponentsInputReactHooks/src/Main.purs
+++ b/recipes/ComponentsInputReactHooks/src/Main.purs
@@ -1,6 +1,7 @@
 module ComponentsInputReactHooks.Main where
 
 import Prelude
+
 import Data.Maybe (Maybe(..))
 import Effect (Effect)
 import Effect.Exception (throw)

--- a/recipes/ComponentsMultiTypeHalogenHooks/src/Main.purs
+++ b/recipes/ComponentsMultiTypeHalogenHooks/src/Main.purs
@@ -24,7 +24,7 @@ main =
     void $ runUI containerComponent unit body
 
 _button :: Proxy "button"
-_button = Proxy 
+_button = Proxy
 
 containerComponent
   :: forall unusedQuery unusedInput unusedOutput anyMonad
@@ -40,39 +40,39 @@ containerComponent = Hooks.component \rec _ -> Hooks.do
 
   Hooks.pure $
     HH.div_
-    [ HH.div
-        [ HP.class_ (H.ClassName "box")]
-        [ HH.h1_ [ HH.text "Component A" ]
-        , HH.slot _a unit componentA unit absurd
-        ]
-    , HH.div
-        [ HP.class_ (H.ClassName "box")]
-        [ HH.h1_ [ HH.text "Component B" ]
-        , HH.slot _b unit componentB unit absurd
-        ]
-    , HH.div
-        [ HP.class_ (H.ClassName "box")]
-        [ HH.h1_ [ HH.text "Component C" ]
-        , HH.slot _c unit componentC unit absurd
-        ]
-    , HH.p_
-        [ HH.text "Last observed states:"]
-    , HH.ul_
-        [ HH.li_ [ HH.text ("Component A: " <> show state.a) ]
-        , HH.li_ [ HH.text ("Component B: " <> show state.b) ]
-        , HH.li_ [ HH.text ("Component C: " <> show state.c) ]
-        ]
-    , HH.button
-        [ HE.onClick \_ -> do
-            a <- Hooks.query rec.slotToken _a unit (H.mkRequest IsOn)
-            b <- Hooks.query rec.slotToken _b unit (H.mkRequest GetCount)
-            c <- Hooks.query rec.slotToken _c unit (H.mkRequest GetValue)
-            Hooks.put stateIdx { a, b, c }
-        ]
-        [ HH.text "Check states now" ]
-    , HH.p_
-        [ HH.text ("Parent has been rendered " <> show parentRenders <> " time(s)") ]
-    ]
+      [ HH.div
+          [ HP.class_ (H.ClassName "box") ]
+          [ HH.h1_ [ HH.text "Component A" ]
+          , HH.slot _a unit componentA unit absurd
+          ]
+      , HH.div
+          [ HP.class_ (H.ClassName "box") ]
+          [ HH.h1_ [ HH.text "Component B" ]
+          , HH.slot _b unit componentB unit absurd
+          ]
+      , HH.div
+          [ HP.class_ (H.ClassName "box") ]
+          [ HH.h1_ [ HH.text "Component C" ]
+          , HH.slot _c unit componentC unit absurd
+          ]
+      , HH.p_
+          [ HH.text "Last observed states:" ]
+      , HH.ul_
+          [ HH.li_ [ HH.text ("Component A: " <> show state.a) ]
+          , HH.li_ [ HH.text ("Component B: " <> show state.b) ]
+          , HH.li_ [ HH.text ("Component C: " <> show state.c) ]
+          ]
+      , HH.button
+          [ HE.onClick \_ -> do
+              a <- Hooks.query rec.slotToken _a unit (H.mkRequest IsOn)
+              b <- Hooks.query rec.slotToken _b unit (H.mkRequest GetCount)
+              c <- Hooks.query rec.slotToken _c unit (H.mkRequest GetValue)
+              Hooks.put stateIdx { a, b, c }
+          ]
+          [ HH.text "Check states now" ]
+      , HH.p_
+          [ HH.text ("Parent has been rendered " <> show parentRenders <> " time(s)") ]
+      ]
 
 data QueryA a = IsOn (Boolean -> a)
 
@@ -87,12 +87,13 @@ componentA = Hooks.component \rec _ -> Hooks.do
       pure $ Just $ reply isEnabled
   Hooks.pure $
     HH.div_
-    [ HH.p_ [ HH.text "Toggle me!" ]
-    , HH.button
-        [ HE.onClick \_ -> do
-            Hooks.modify_ enabledIdx not ]
-        [ HH.text (if enabled then "On" else "Off") ]
-    ]
+      [ HH.p_ [ HH.text "Toggle me!" ]
+      , HH.button
+          [ HE.onClick \_ -> do
+              Hooks.modify_ enabledIdx not
+          ]
+          [ HH.text (if enabled then "On" else "Off") ]
+      ]
 
 data QueryB a = GetCount (Int -> a)
 
@@ -107,14 +108,14 @@ componentB = Hooks.component \rec _ -> Hooks.do
       pure $ Just $ reply currentCount
   Hooks.pure $
     HH.div_
-    [ HH.p_
-        [ HH.text "Current value: "
-        , HH.strong_ [ HH.text (show count) ]
-        ]
-    , HH.button
-        [ HE.onClick \_ -> Hooks.modify_ countIdx (_ + 1) ]
-        [ HH.text ("Increment") ]
-    ]
+      [ HH.p_
+          [ HH.text "Current value: "
+          , HH.strong_ [ HH.text (show count) ]
+          ]
+      , HH.button
+          [ HE.onClick \_ -> Hooks.modify_ countIdx (_ + 1) ]
+          [ HH.text ("Increment") ]
+      ]
 
 data QueryC a = GetValue (String -> a)
 
@@ -129,12 +130,12 @@ componentC = Hooks.component \rec _ -> Hooks.do
       pure $ Just $ reply value
   Hooks.pure $
     HH.label_
-    [ HH.p_ [ HH.text "What do you have to say?" ]
-    , HH.input
-        [ HP.value state
-        , HE.onValueInput (Hooks.put stateIdx)
-        ]
-    ]
+      [ HH.p_ [ HH.text "What do you have to say?" ]
+      , HH.input
+          [ HP.value state
+          , HE.onValueInput (Hooks.put stateIdx)
+          ]
+      ]
 
 useRenderCount
   :: forall m a

--- a/recipes/ComponentsMultiTypeReactHooks/src/Main.purs
+++ b/recipes/ComponentsMultiTypeReactHooks/src/Main.purs
@@ -1,6 +1,7 @@
 module ComponentsMultiTypeReactHooks.Main where
 
 import Prelude
+
 import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Tuple (fst)
 import Effect (Effect)
@@ -98,8 +99,7 @@ mkContainer = do
               [ R.text ("Parent has been rendered " <> show parentRenders <> " time(s)") ]
           ]
 
-type SetState state
-  = (state -> state) -> Effect Unit
+type SetState state = (state -> state) -> Effect Unit
 
 mkComponentA :: Component (Boolean /\ SetState Boolean)
 mkComponentA =

--- a/recipes/ComponentsReactHooks/src/Main.purs
+++ b/recipes/ComponentsReactHooks/src/Main.purs
@@ -1,6 +1,7 @@
 module ComponentsReactHooks.Main where
 
 import Prelude
+
 import Data.Maybe (Maybe(..), maybe)
 import Effect (Effect)
 import Effect.Exception (throw)
@@ -57,8 +58,8 @@ mkContainer = do
           , R.p_
               [ R.text
                   $ "Last time I checked, the button was: "
-                  <> (maybe "(not checked yet)" (if _ then "on" else "off") buttonState)
-                  <> ". "
+                      <> (maybe "(not checked yet)" (if _ then "on" else "off") buttonState)
+                      <> ". "
               , R.button
                   { onClick: handler_ (setButtonState \_ -> Just enabled)
                   , children: [ R.text "Check now" ]

--- a/recipes/DateTimeBasicsLog/src/Main.purs
+++ b/recipes/DateTimeBasicsLog/src/Main.purs
@@ -14,20 +14,23 @@ import Partial.Unsafe (unsafePartial)
 
 main :: Effect Unit
 main = do
-  log "To create a specific part of a `Time` value, you must use \
-      \the `toEnum` function. This ensures that the value you provide \
-      \is within the correct bounds. "
-  log "For example, a Minute must be between 0 and 59. If you happen \
-      \to pass it -1, what should it's value be? Should it be clamped to 0? \
-      \Or should it be set to 59? Rather than deciding for you, it forces \
-      \you to do the checking by using `toEnum` to return a `Maybe Minute`."
+  log
+    "To create a specific part of a `Time` value, you must use \
+    \the `toEnum` function. This ensures that the value you provide \
+    \is within the correct bounds. "
+  log
+    "For example, a Minute must be between 0 and 59. If you happen \
+    \to pass it -1, what should it's value be? Should it be clamped to 0? \
+    \Or should it be set to 59? Rather than deciding for you, it forces \
+    \you to do the checking by using `toEnum` to return a `Maybe Minute`."
 
   log $ "toEnum 4: " <> show (toEnum 4 :: Maybe Minute)
   log $ "toEnum -8: " <> show (toEnum (-8) :: Maybe Minute)
   log $ "toEnum 69: " <> show (toEnum 69 :: Maybe Minute)
 
-  log "The same goes for Hour (0 - 23), Second (0 - 59), and \
-      \Millisecond (0 - 999)."
+  log
+    "The same goes for Hour (0 - 23), Second (0 - 59), and \
+    \Millisecond (0 - 999)."
   log $ "toEnum 4: " <> show (toEnum 4 :: Maybe Hour)
   log $ "toEnum -8: " <> show (toEnum (-8) :: Maybe Hour)
   log $ "toEnum 69: " <> show (toEnum 69 :: Maybe Hour)
@@ -38,11 +41,11 @@ main = do
     mkTime :: Int -> Int -> Int -> Int -> Maybe Time
     mkTime h m s ms = do
       Time <$> toEnum h
-           <*> toEnum m
-           <*> toEnum s
-           <*> toEnum ms
+        <*> toEnum m
+        <*> toEnum s
+        <*> toEnum ms
 
-  log $ "mkTime 4 24 4 3: " <> show (mkTime 4 24 4 3)       -- valid
+  log $ "mkTime 4 24 4 3: " <> show (mkTime 4 24 4 3) -- valid
   log $ "mkTime 42 842 2 -42: " <> show (mkTime 42 842 2 (-42)) -- invalid
 
   log "To create a `Date` value, we use the `Maybe` monad again:"

--- a/recipes/DebuggingLog/src/Main.purs
+++ b/recipes/DebuggingLog/src/Main.purs
@@ -16,14 +16,16 @@ main :: Effect Unit
 main = do
   log "When we are in the 'Effect' monad, we can print content to the console."
   launchAff_ do
-    liftEffect $ log $ "We can still print values to the console as long as \
-                       \the monad in question implements the MonadEffect \
-                       \type class. Since `Aff` implements MonadEffect, we \
-                       \can lift that effect into `Aff`."
+    liftEffect $ log $
+      "We can still print values to the console as long as \
+      \the monad in question implements the MonadEffect \
+      \type class. Since `Aff` implements MonadEffect, we \
+      \can lift that effect into `Aff`."
 
-  log "However, there are times when we want to debug some code and wish \
-      \to use print-based debugging. Since PureScript is pure, how do we \
-      \do that?"
+  log
+    "However, there are times when we want to debug some code and wish \
+    \to use print-based debugging. Since PureScript is pure, how do we \
+    \do that?"
 
   usingSpy
 
@@ -41,13 +43,13 @@ usingSpy = do
   let
     x = 5
     y = spy "y" 8
-    adt = spy "adt" $ MyADT 1 (Tuple 4 ["a", "b"]) { foo: "foo value" }
+    adt = spy "adt" $ MyADT 1 (Tuple 4 [ "a", "b" ]) { foo: "foo value" }
     function = spy "function" $ \intValue -> show $ 4 + intValue
 
     -- quick way of debugging something without showing it or using a
     -- variable name
     _ = spy "debug for me what x + y is" $ x + y
-    arrayOfStrings = spy "debug some array" $ map show [1, 2, 3, 4, 5]
+    arrayOfStrings = spy "debug some array" $ map show [ 1, 2, 3, 4, 5 ]
 
     -- quickly drop-in `spy` to see every step of a recursive function
     fact :: Int -> Int -> Int
@@ -56,16 +58,18 @@ usingSpy = do
 
     _ = fact 5 1
 
-  log $ "Thus, spying is an effective way of quickly adding debugging where \
-        \you need it without affecting any other part of your code. \
-        \Note: you should not use `spy` to do logging in production code. \
-        \Use a proper logger in production code."
+  log $
+    "Thus, spying is an effective way of quickly adding debugging where \
+    \you need it without affecting any other part of your code. \
+    \Note: you should not use `spy` to do logging in production code. \
+    \Use a proper logger in production code."
 
 usingTraceM :: Effect Unit
 usingTraceM = do
   log "usingTraceM"
-  traceM "Notice how this text's color is different than what is outputted \
-         \via `log`."
+  traceM
+    "Notice how this text's color is different than what is outputted \
+    \via `log`."
 
   let
     localMutationComputation
@@ -84,6 +88,7 @@ usingTraceM = do
 
 compareSpyAndTraceM :: Effect Unit
 compareSpyAndTraceM = do
-  let x = 5
-      _ = spy "x" x
+  let
+    x = 5
+    _ = spy "x" x
   traceM x

--- a/recipes/DiceCLI/src/Main.purs
+++ b/recipes/DiceCLI/src/Main.purs
@@ -1,10 +1,11 @@
 module DiceCLI.Main where
 
 import Prelude
+
 import Effect (Effect)
 import Effect.Console (log)
 import Effect.Random (randomInt)
-import Node.ReadLine (prompt, close, setLineHandler, setPrompt, noCompletion, createConsoleInterface)
+import Node.ReadLine (close, createConsoleInterface, noCompletion, prompt, setLineHandler, setPrompt)
 
 main :: Effect Unit
 main = do

--- a/recipes/DiceLog/src/Main.purs
+++ b/recipes/DiceLog/src/Main.purs
@@ -1,6 +1,7 @@
 module DiceLog.Main where
 
 import Prelude
+
 import Effect (Effect)
 import Effect.Console (log)
 import Effect.Random (randomInt)

--- a/recipes/DragAndDropHalogenHooks/src/Main.purs
+++ b/recipes/DragAndDropHalogenHooks/src/Main.purs
@@ -45,57 +45,57 @@ hookComponent = Hooks.component \_ _ -> Hooks.do
   files /\ filesIdx <- Hooks.useState []
   Hooks.pure $
     HH.div
-    [ HC.style do
-        border dashed (px 6.0) $ if hover then CSS.fromInt 0xB10DC9 else CSS.fromInt 0xcccccc
-        borderRadius (px 20.0) (px 20.0) (px 20.0) (px 20.0)
-        width (px 480.0)
-        height (px 100.0)
-        margin (px 100.0) (px 100.0) (px 100.0) (px 100.0)
-        padding (px 20.0) (px 20.0) (px 20.0) (px 20.0)
-        display flex
-        flexDirection column
-        justifyContent center
-        alignItems center
-    , HE.onDragEnter \e -> do
-        preventDefault DragEvent.toEvent e
-        Hooks.put hoverIdx true
-    , HE.onDragOver \e -> do
-        preventDefault DragEvent.toEvent e
-        Hooks.put hoverIdx true
-    , HE.onDragLeave \e -> do
-        preventDefault DragEvent.toEvent e
-        Hooks.put hoverIdx false
-    , HE.onDrop \e -> do
-        preventDefault DragEvent.toEvent e
-        let
-          mbFileList = DataTransfer.files $ dataTransfer e
-          fileArray = maybe [] FileList.items mbFileList
-        Hooks.put filesIdx fileArray
-        Hooks.put hoverIdx false
-    ]
-    [ HH.label
-      -- simulate button-like appearance
       [ HC.style do
-          margin (px 4.0) (px 4.0) (px 4.0) (px 4.0)
-          border solid (px 2.0) (CSS.fromInt 0xAAAAAA)
+          border dashed (px 6.0) $ if hover then CSS.fromInt 0xB10DC9 else CSS.fromInt 0xcccccc
           borderRadius (px 20.0) (px 20.0) (px 20.0) (px 20.0)
+          width (px 480.0)
+          height (px 100.0)
+          margin (px 100.0) (px 100.0) (px 100.0) (px 100.0)
           padding (px 20.0) (px 20.0) (px 20.0) (px 20.0)
-          backgroundColor (CSS.rgb 3 169 244)
-      , HP.class_ $ ClassName "otherCssNotInPurescript-Css"
+          display flex
+          flexDirection column
+          justifyContent center
+          alignItems center
+      , HE.onDragEnter \e -> do
+          preventDefault DragEvent.toEvent e
+          Hooks.put hoverIdx true
+      , HE.onDragOver \e -> do
+          preventDefault DragEvent.toEvent e
+          Hooks.put hoverIdx true
+      , HE.onDragLeave \e -> do
+          preventDefault DragEvent.toEvent e
+          Hooks.put hoverIdx false
+      , HE.onDrop \e -> do
+          preventDefault DragEvent.toEvent e
+          let
+            mbFileList = DataTransfer.files $ dataTransfer e
+            fileArray = maybe [] FileList.items mbFileList
+          Hooks.put filesIdx fileArray
+          Hooks.put hoverIdx false
       ]
-      [ HH.text "Upload images"
-      , HH.input
-          [ HC.style $ display displayNone
-          , HP.type_ InputFile
-          , HP.multiple true
-          , HP.accept $ mediaType $ MediaType "image/*"
-          , HE.onFileUpload \fileArray -> Hooks.put filesIdx fileArray
+      [ HH.label
+          -- simulate button-like appearance
+          [ HC.style do
+              margin (px 4.0) (px 4.0) (px 4.0) (px 4.0)
+              border solid (px 2.0) (CSS.fromInt 0xAAAAAA)
+              borderRadius (px 20.0) (px 20.0) (px 20.0) (px 20.0)
+              padding (px 20.0) (px 20.0) (px 20.0) (px 20.0)
+              backgroundColor (CSS.rgb 3 169 244)
+          , HP.class_ $ ClassName "otherCssNotInPurescript-Css"
           ]
+          [ HH.text "Upload images"
+          , HH.input
+              [ HC.style $ display displayNone
+              , HP.type_ InputFile
+              , HP.multiple true
+              , HP.accept $ mediaType $ MediaType "image/*"
+              , HE.onFileUpload \fileArray -> Hooks.put filesIdx fileArray
+              ]
+          ]
+      , HH.span
+          [ HC.style $ color $ CSS.fromInt 0xcccccc ]
+          [ HH.text $ i "{ files = " (show $ map File.name files) ", hover = " (toUpper $ show hover) " }" ]
       ]
-    , HH.span
-      [ HC.style $ color $ CSS.fromInt 0xcccccc ]
-      [ HH.text $ i "{ files = "(show $ map File.name files)", hover = "(toUpper $ show hover)" }" ]
-    ]
 {-
 The easiest way to create a file input dialog is with the input element:
 

--- a/recipes/DragAndDropReactHooks/src/Main.purs
+++ b/recipes/DragAndDropReactHooks/src/Main.purs
@@ -1,6 +1,7 @@
 module DragAndDropReactHooks.Main where
 
 import Prelude
+
 import Data.Foldable as Foldable
 import Data.Maybe (Maybe(..))
 import Data.Nullable as Nullable

--- a/recipes/FileUploadHalogenHooks/src/Main.purs
+++ b/recipes/FileUploadHalogenHooks/src/Main.purs
@@ -2,9 +2,9 @@ module FileUploadHalogenHooks.Main where
 
 import Prelude
 
-import Data.Tuple.Nested ((/\))
 import DOM.HTML.Indexed.InputType (InputType(..))
 import Data.Maybe (Maybe(..))
+import Data.Tuple.Nested ((/\))
 import Effect (Effect)
 import Halogen as H
 import Halogen.Aff as HA
@@ -28,10 +28,10 @@ hookComponent = Hooks.component \_ _ -> Hooks.do
   files /\ filesIdx <- Hooks.useState []
   Hooks.pure $
     HH.div_
-    [ HH.input
-        [ HP.type_ InputFile
-        , HP.multiple true
-        , HE.onFileUpload \fileArray -> Hooks.put filesIdx fileArray
-        ]
-    , HH.div_ [ HH.text $ show $ map File.name files ]
-    ]
+      [ HH.input
+          [ HP.type_ InputFile
+          , HP.multiple true
+          , HE.onFileUpload \fileArray -> Hooks.put filesIdx fileArray
+          ]
+      , HH.div_ [ HH.text $ show $ map File.name files ]
+      ]

--- a/recipes/FileUploadReactHooks/src/Main.purs
+++ b/recipes/FileUploadReactHooks/src/Main.purs
@@ -1,6 +1,7 @@
 module FileUploadReactHooks.Main where
 
 import Prelude
+
 import Data.Foldable (for_)
 import Data.Maybe (Maybe(..))
 import Effect (Effect)

--- a/recipes/FindDomElementJs/src/Main.purs
+++ b/recipes/FindDomElementJs/src/Main.purs
@@ -35,8 +35,10 @@ main = do
 
   mbThirdParInDivInDiv <- querySelector (QuerySelector "div.example div.third p.c") docAsParent
   for_ mbThirdParInDivInDiv \_ -> do
-    log $ "Found third `p` in a `div` with `third` class in a `div` with \
-          \`example` class."
+    log $
+      "Found third `p` in a `div` with `third` class in a `div` with \
+      \`example` class."
 
-  log $ "If any of the above queries did not find their corresponding element, \
-        \please open an issue in the PureScript cookbook repository."
+  log $
+    "If any of the above queries did not find their corresponding element, \
+    \please open an issue in the PureScript cookbook repository."

--- a/recipes/FormsReactHooks/src/Main.purs
+++ b/recipes/FormsReactHooks/src/Main.purs
@@ -1,6 +1,7 @@
 module FormsReactHooks.Main where
 
 import Prelude
+
 import Data.Maybe (Maybe(..), fromMaybe)
 import Effect (Effect)
 import Effect.Exception (throw)
@@ -8,7 +9,7 @@ import React.Basic.DOM (css, render)
 import React.Basic.DOM as R
 import React.Basic.DOM.Events (preventDefault, targetValue)
 import React.Basic.Events (EventHandler, handler)
-import React.Basic.Hooks (Component, component, useState, (/\), Hook, UseState, type (/\))
+import React.Basic.Hooks (type (/\), Component, Hook, UseState, component, useState, (/\))
 import React.Basic.Hooks as React
 import Web.HTML (window)
 import Web.HTML.HTMLDocument (body)
@@ -61,11 +62,11 @@ mkForm = do
               ]
           }
 
-useInput ::
-  String ->
-  Hook
-    (UseState String)
-    (String /\ EventHandler)
+useInput
+  :: String
+  -> Hook
+       (UseState String)
+       (String /\ EventHandler)
 useInput initialValue = React.do
   value /\ setValue <- useState initialValue
   let

--- a/recipes/GroceriesHalogenHooks/src/Main.purs
+++ b/recipes/GroceriesHalogenHooks/src/Main.purs
@@ -1,6 +1,7 @@
 module GroceriesHalogenHooks.Main where
 
 import Prelude
+
 import Data.Maybe (Maybe(..))
 import Effect (Effect)
 import Halogen as H
@@ -15,9 +16,9 @@ main =
     body <- HA.awaitBody
     void $ runUI hookComponent Nothing body
 
-hookComponent ::
-  forall unusedQuery unusedInput unusedOutput anyMonad.
-  H.Component unusedQuery unusedInput unusedOutput anyMonad
+hookComponent
+  :: forall unusedQuery unusedInput unusedOutput anyMonad
+   . H.Component unusedQuery unusedInput unusedOutput anyMonad
 hookComponent =
   Hooks.component \_ _ -> Hooks.do
     Hooks.pure

--- a/recipes/GroceriesJs/src/Main.purs
+++ b/recipes/GroceriesJs/src/Main.purs
@@ -1,6 +1,7 @@
 module GroceriesJs.Main where
 
 import Prelude
+
 import Data.Foldable (traverse_)
 import Data.Maybe (maybe)
 import Effect (Effect)

--- a/recipes/GroceriesReactHooks/src/Main.purs
+++ b/recipes/GroceriesReactHooks/src/Main.purs
@@ -1,6 +1,7 @@
 module GroceriesReactHooks.Main where
 
 import Prelude
+
 import Data.Maybe (Maybe(..))
 import Effect (Effect)
 import Effect.Exception (throw)

--- a/recipes/HelloHalogenHooks/src/Main.purs
+++ b/recipes/HelloHalogenHooks/src/Main.purs
@@ -1,13 +1,14 @@
 module HelloHalogenHooks.Main where
 
 import Prelude
+
 import Data.Maybe (Maybe(..))
 import Effect (Effect)
 import Halogen as H
-import Halogen.HTML as HH
 import Halogen.Aff as HA
-import Halogen.VDom.Driver (runUI)
+import Halogen.HTML as HH
 import Halogen.Hooks as Hooks
+import Halogen.VDom.Driver (runUI)
 
 main :: Effect Unit
 main =

--- a/recipes/HelloJs/src/Main.purs
+++ b/recipes/HelloJs/src/Main.purs
@@ -1,6 +1,7 @@
 module HelloJs.Main where
 
 import Prelude
+
 import Data.Maybe (maybe)
 import Effect (Effect)
 import Effect.Exception (throw)

--- a/recipes/HeterogeneousLog/src/Main.purs
+++ b/recipes/HeterogeneousLog/src/Main.purs
@@ -39,7 +39,7 @@ demoMapping = do
         { field1: Tuple 1 true
         , field2: Tuple true 1
         , field3: Tuple "a value" unit
-        , field4: Tuple (Just [1]) (Just [2])
+        , field4: Tuple (Just [ 1 ]) (Just [ 2 ])
         }
     log $ append "GetFirst: " $ show $ getFirst recordValue
 
@@ -62,7 +62,7 @@ else instance Fail (Text "This only works on fields whose types are Tuple") => M
 getFirst
   :: forall rowsIn rowsInRL rowsOut
    . RL.RowToList rowsIn rowsInRL
-  => HMap GetFirst  { | rowsIn } { | rowsOut }
+  => HMap GetFirst { | rowsIn } { | rowsOut }
   => { | rowsIn }
   -> { | rowsOut }
 getFirst r = hmap GetFirst r
@@ -92,7 +92,7 @@ demoMappingWithIndex = do
         { field1: Tuple 1 true
         , field2: Tuple true 1
         , field3: Tuple "a value" unit
-        , field4: Tuple (Just [1]) (Just [2])
+        , field4: Tuple (Just [ 1 ]) (Just [ 2 ])
         }
     log $ append "ReflectFieldLabels: " $ show $ reflectFieldLabels recordValue
 
@@ -146,8 +146,8 @@ demoFoldingWithIndex = do
       prefix = RenameFields :: RenameFields (Prepend "prefix-")
       suffix = RenameFields :: RenameFields (Append "-suffix")
 
-    log $ append "Prefix: " $ show (renameFields prefix { one: 1, two: "foo"})
-    log $ append "Suffix: " $ show (renameFields suffix { one: 1, two: "foo"})
+    log $ append "Prefix: " $ show (renameFields prefix { one: 1, two: "foo" })
+    log $ append "Suffix: " $ show (renameFields suffix { one: 1, two: "foo" })
 
 data RenameFields :: FieldRenamer -> Type
 data RenameFields renamer = RenameFields
@@ -163,7 +163,7 @@ instance
   , Row.Lacks newName withoutNewField
   , Row.Cons newName fieldType withoutNewField withNewField
   ) =>
-  FoldingWithIndex (RenameFields (Prepend prefix)) (Proxy fieldName) { | withoutNewField } fieldType { | withNewField }  where
+  FoldingWithIndex (RenameFields (Prepend prefix)) (Proxy fieldName) { | withoutNewField } fieldType { | withNewField } where
   foldingWithIndex RenameFields _ acc next =
     Record.insert (Proxy :: Proxy newName) next acc
 
@@ -173,7 +173,7 @@ else instance
   , Row.Lacks newName withoutNewField
   , Row.Cons newName fieldType withoutNewField withNewField
   ) =>
-  FoldingWithIndex (RenameFields (Append suffix)) (Proxy fieldName) { | withoutNewField } fieldType { | withNewField }  where
+  FoldingWithIndex (RenameFields (Append suffix)) (Proxy fieldName) { | withoutNewField } fieldType { | withNewField } where
   foldingWithIndex RenameFields _ acc next =
     Record.insert (Proxy :: Proxy newName) next acc
 
@@ -183,8 +183,8 @@ else instance
 renameFields
   :: forall rowsIn rowsInRL modification rowsOut
    . RL.RowToList rowsIn rowsInRL
-  => HFoldlWithIndex (RenameFields modification) { } { | rowsIn } { | rowsOut }
+  => HFoldlWithIndex (RenameFields modification) {} { | rowsIn } { | rowsOut }
   => RenameFields modification
   -> { | rowsIn }
   -> { | rowsOut }
-renameFields renamer r = hfoldlWithIndex renamer { } r
+renameFields renamer r = hfoldlWithIndex renamer {} r

--- a/recipes/HeterogenousArrayLog/src/Main.purs
+++ b/recipes/HeterogenousArrayLog/src/Main.purs
@@ -1,6 +1,7 @@
 module HeterogenousArrayLog.Main where
 
 import Prelude
+
 import Data.Variant (Variant)
 import Data.Variant as Variant
 import Effect (Effect)
@@ -54,13 +55,12 @@ heterogenousArrayViaSumType = do
 --
 -- Variant Type for array elements
 -- Created from a "row type" of tags and other types
-type VariantType
-  = Variant
-      ( typeLevelString :: String
-      , int :: Int
-      , boolean :: Boolean
-      , "this type level string must match the label of the row" :: Number
-      )
+type VariantType = Variant
+  ( typeLevelString :: String
+  , int :: Int
+  , boolean :: Boolean
+  , "this type level string must match the label of the row" :: Number
+  )
 
 heterogenousArrayViaVariant :: Effect Unit
 heterogenousArrayViaVariant = do

--- a/recipes/ImagePreviewsHalogenHooks/src/Main.purs
+++ b/recipes/ImagePreviewsHalogenHooks/src/Main.purs
@@ -50,113 +50,113 @@ hookComponent = Hooks.component \_ _ -> Hooks.do
   urls /\ urlsIdx <- Hooks.useState []
   Hooks.pure $
     HH.div
-    [ HC.style do
-        border dashed (px 6.0) $ if hover then CSS.fromInt 0xB10DC9 else CSS.fromInt 0xcccccc
-        borderRadius (px 20.0) (px 20.0) (px 20.0) (px 20.0)
-        width (px 480.0)
-        height (px 100.0)
-        margin (px 100.0) (px 100.0) (px 100.0) (px 100.0)
-        padding (px 40.0) (px 40.0) (px 40.0) (px 40.0)
-        display flex
-        flexDirection column
-        justifyContent center
-        alignItems center
-    , HE.onDragEnter \e -> do
-        preventDefault DragEvent.toEvent e
-        Hooks.put hoverIdx true
-    , HE.onDragOver \e -> do
-        preventDefault DragEvent.toEvent e
-        Hooks.put hoverIdx true
-    , HE.onDragLeave \e -> do
-        preventDefault DragEvent.toEvent e
-        Hooks.put hoverIdx false
-    , HE.onDrop \e -> do
-        preventDefault DragEvent.toEvent e
-        let
-          mbFileList = DataTransfer.files $ dataTransfer e
-          fileArray = maybe [] FileList.items mbFileList
-        putFileUrls ref urlsIdx fileArray
-    ]
-    -- Note: Elm uses a button that, when clicked, will do the following:
-    -- 1. create an input element
-    -- 2. add it to the DOM
-    -- 3. create a mouse event
-    -- 4. dispatch the mouse event to the input element
-    -- 5. (implication) file dialogue appears
-    -- 6. user selects a file
-    -- 7. input event handler runs a callback using user's selected file
-    -- 8. input element is removed from DOM
-    --
-    -- The approach used below is based on this SO answer:
-    -- https://stackoverflow.com/a/47094148
-    [ HH.label
-      [ HP.for "file-input" ]
-      [ HH.div
-        -- simulate button-like appearance
-        [ HC.style do
-            margin (px 4.0) (px 4.0) (px 4.0) (px 4.0)
-            border solid (px 2.0) (CSS.fromInt 0xAAAAAA)
-            borderRadius (px 20.0) (px 20.0) (px 20.0) (px 20.0)
-            padding (px 20.0) (px 20.0) (px 20.0) (px 20.0)
-        , HP.class_ $ ClassName "otherCssNotInPurescript-Css"
-        ]
-        [ HH.text "Upload images" ]
+      [ HC.style do
+          border dashed (px 6.0) $ if hover then CSS.fromInt 0xB10DC9 else CSS.fromInt 0xcccccc
+          borderRadius (px 20.0) (px 20.0) (px 20.0) (px 20.0)
+          width (px 480.0)
+          height (px 100.0)
+          margin (px 100.0) (px 100.0) (px 100.0) (px 100.0)
+          padding (px 40.0) (px 40.0) (px 40.0) (px 40.0)
+          display flex
+          flexDirection column
+          justifyContent center
+          alignItems center
+      , HE.onDragEnter \e -> do
+          preventDefault DragEvent.toEvent e
+          Hooks.put hoverIdx true
+      , HE.onDragOver \e -> do
+          preventDefault DragEvent.toEvent e
+          Hooks.put hoverIdx true
+      , HE.onDragLeave \e -> do
+          preventDefault DragEvent.toEvent e
+          Hooks.put hoverIdx false
+      , HE.onDrop \e -> do
+          preventDefault DragEvent.toEvent e
+          let
+            mbFileList = DataTransfer.files $ dataTransfer e
+            fileArray = maybe [] FileList.items mbFileList
+          putFileUrls ref urlsIdx fileArray
       ]
-    , HH.input
-        [ HP.id "file-input"
-        , HC.style $ display displayNone
-        , HP.type_ InputFile
-        , HP.accept $ mediaType $ MediaType "images/*"
-        , HP.multiple true
-        , HE.onFileUpload \fileArray -> do
-            putFileUrls ref urlsIdx fileArray
-        ]
-    , HH.div
+      -- Note: Elm uses a button that, when clicked, will do the following:
+      -- 1. create an input element
+      -- 2. add it to the DOM
+      -- 3. create a mouse event
+      -- 4. dispatch the mouse event to the input element
+      -- 5. (implication) file dialogue appears
+      -- 6. user selects a file
+      -- 7. input event handler runs a callback using user's selected file
+      -- 8. input element is removed from DOM
+      --
+      -- The approach used below is based on this SO answer:
+      -- https://stackoverflow.com/a/47094148
+      [ HH.label
+          [ HP.for "file-input" ]
+          [ HH.div
+              -- simulate button-like appearance
+              [ HC.style do
+                  margin (px 4.0) (px 4.0) (px 4.0) (px 4.0)
+                  border solid (px 2.0) (CSS.fromInt 0xAAAAAA)
+                  borderRadius (px 20.0) (px 20.0) (px 20.0) (px 20.0)
+                  padding (px 20.0) (px 20.0) (px 20.0) (px 20.0)
+              , HP.class_ $ ClassName "otherCssNotInPurescript-Css"
+              ]
+              [ HH.text "Upload images" ]
+          ]
+      , HH.input
+          [ HP.id "file-input"
+          , HC.style $ display displayNone
+          , HP.type_ InputFile
+          , HP.accept $ mediaType $ MediaType "images/*"
+          , HP.multiple true
+          , HE.onFileUpload \fileArray -> do
+              putFileUrls ref urlsIdx fileArray
+          ]
+      , HH.div
           [ HC.style do
               display flex
               alignItems center
               height (px 60.0)
               padding (px 20.0) (px 20.0) (px 20.0) (px 20.0)
           ]
-          (urls <#> \fileUrl ->
-            HH.div
-              [ HC.style do
-                  width (px 60.0)
-                  height (px 60.0)
-                  backgroundImage $ url fileUrl
-                  backgroundPosition $ placed sideCenter sideCenter
-                  backgroundRepeat noRepeat
-                  backgroundSize contain
-              ]
-              []
+          ( urls <#> \fileUrl ->
+              HH.div
+                [ HC.style do
+                    width (px 60.0)
+                    height (px 60.0)
+                    backgroundImage $ url fileUrl
+                    backgroundPosition $ placed sideCenter sideCenter
+                    backgroundRepeat noRepeat
+                    backgroundSize contain
+                ]
+                []
           )
-    ]
+      ]
   where
-    putFileUrls
-      :: Ref (Array (Effect Unit))
-      -> StateId (Array String)
-      -> Array File
-      -> HookM anyMonad Unit
-    putFileUrls arrayRef idx files = do
-      -- revoke all prior object urls
-      -- by running their effects and ignoring the result
+  putFileUrls
+    :: Ref (Array (Effect Unit))
+    -> StateId (Array String)
+    -> Array File
+    -> HookM anyMonad Unit
+  putFileUrls arrayRef idx files = do
+    -- revoke all prior object urls
+    -- by running their effects and ignoring the result
+    liftEffect do
+      arrayOfRemovePriorObjectUrls <- Ref.read arrayRef
+      sequence_ arrayOfRemovePriorObjectUrls
+
+    arrayOfUrls <- for files \file -> do
       liftEffect do
-        arrayOfRemovePriorObjectUrls <- Ref.read arrayRef
-        sequence_ arrayOfRemovePriorObjectUrls
+        -- create the object url
+        urlString <- createObjectURL (toBlob file)
 
-      arrayOfUrls <- for files \file -> do
-        liftEffect do
-          -- create the object url
-          urlString <- createObjectURL (toBlob file)
+        -- create an effect that, when run, will revoke the url
+        -- and clean up memory
+        let
+          revokeUrl :: Effect Unit
+          revokeUrl = revokeObjectURL urlString
+        -- add that effect to our mutable reference
+        Ref.modify_ (\arr -> arr `snoc` revokeUrl) arrayRef
 
-          -- create an effect that, when run, will revoke the url
-          -- and clean up memory
-          let
-            revokeUrl :: Effect Unit
-            revokeUrl = revokeObjectURL urlString
-          -- add that effect to our mutable reference
-          Ref.modify_ (\arr -> arr `snoc` revokeUrl) arrayRef
-
-          -- now return the original url
-          pure urlString
-      Hooks.put idx arrayOfUrls
+        -- now return the original url
+        pure urlString
+    Hooks.put idx arrayOfUrls

--- a/recipes/ImagePreviewsReactHooks/src/Main.purs
+++ b/recipes/ImagePreviewsReactHooks/src/Main.purs
@@ -1,6 +1,7 @@
 module ImagePreviewsReactHooks.Main where
 
 import Prelude
+
 import Data.Array as Array
 import Data.Foldable as Foldable
 import Data.Maybe (Maybe(..))

--- a/recipes/InterpretHalogenHooks/src/Main.purs
+++ b/recipes/InterpretHalogenHooks/src/Main.purs
@@ -2,8 +2,8 @@ module InterpretHalogenHooks.Main where
 
 import Prelude
 
-import Affjax.Web as AX
 import Affjax.ResponseFormat as AXRF
+import Affjax.Web as AX
 import Control.Monad.Reader (ReaderT, ask, runReaderT)
 import Data.Either (either)
 import Data.Maybe (Maybe(..), fromMaybe)

--- a/recipes/LifecycleHalogenHooks/src/Main.purs
+++ b/recipes/LifecycleHalogenHooks/src/Main.purs
@@ -29,7 +29,7 @@ rootComponent
    . MonadEffect anyMonad
   => H.Component unusedQuery unusedInput unusedOutput anyMonad
 rootComponent = Hooks.component \_ _ -> Hooks.do
-  state /\ stateIdx <- Hooks.useState { currentId: 0, slots: []}
+  state /\ stateIdx <- Hooks.useState { currentId: 0, slots: [] }
   Hooks.useLifecycleEffect do
     liftEffect $ log "Initialize Root"
     pure Nothing
@@ -38,10 +38,10 @@ rootComponent = Hooks.component \_ _ -> Hooks.do
     HH.div_
       [ HH.button
           [ HE.onClick \_ -> do
-            Hooks.modify_ stateIdx \s ->
-              { currentId: s.currentId + 1
-              , slots: snoc s.slots s.currentId
-              }
+              Hooks.modify_ stateIdx \s ->
+                { currentId: s.currentId + 1
+                , slots: snoc s.slots s.currentId
+                }
           ]
           [ HH.text "Add" ]
       , HH.button
@@ -62,16 +62,16 @@ rootComponent = Hooks.component \_ _ -> Hooks.do
               ]
       ]
   where
-    _child = Proxy :: Proxy "child"
+  _child = Proxy :: Proxy "child"
 
-    listen :: Int -> Message -> _
-    listen i m = do
-      let
-        msg = case m of
-          Initialized -> "Heard Initialized from child" <> show i
-          Finalized -> "Heard Finalized from child" <> show i
-          Reported msg' -> "Re-reporting from child" <> show i <> ": " <> msg'
-      liftEffect $ log ("Root >>> " <> msg)
+  listen :: Int -> Message -> _
+  listen i m = do
+    let
+      msg = case m of
+        Initialized -> "Heard Initialized from child" <> show i
+        Finalized -> "Heard Finalized from child" <> show i
+        Reported msg' -> "Re-reporting from child" <> show i <> ": " <> msg'
+    liftEffect $ log ("Root >>> " <> msg)
 
 data Message
   = Initialized
@@ -95,23 +95,23 @@ childComponent id = Hooks.component \rec _ -> Hooks.do
     HH.div_
       [ HH.text ("Child " <> show id)
       , HH.ul_
-        [ HH.slot _cell 0 (cell 0) unit (listen rec.outputToken 0)
-        , HH.slot _cell 1 (cell 1) unit (listen rec.outputToken 1)
-        , HH.slot _cell 2 (cell 2) unit (listen rec.outputToken 2)
-        ]
+          [ HH.slot _cell 0 (cell 0) unit (listen rec.outputToken 0)
+          , HH.slot _cell 1 (cell 1) unit (listen rec.outputToken 1)
+          , HH.slot _cell 2 (cell 2) unit (listen rec.outputToken 2)
+          ]
       ]
   where
-    _cell = Proxy :: Proxy "cell"
+  _cell = Proxy :: Proxy "cell"
 
-    listen :: _ -> Int -> Message -> _
-    listen outputToken i m = do
-      let
-        msg = case m of
-          Initialized -> "Heard Initialized from cell" <> show i
-          Finalized -> "Heard Finalized from cell" <> show i
-          Reported msg' -> "Re-reporting from cell" <> show i <> ": " <> msg'
-      liftEffect $ log $ "Child " <> show i <> " >>> " <> msg
-      Hooks.raise outputToken (Reported msg)
+  listen :: _ -> Int -> Message -> _
+  listen outputToken i m = do
+    let
+      msg = case m of
+        Initialized -> "Heard Initialized from cell" <> show i
+        Finalized -> "Heard Finalized from cell" <> show i
+        Reported msg' -> "Re-reporting from cell" <> show i <> ": " <> msg'
+    liftEffect $ log $ "Child " <> show i <> " >>> " <> msg
+    Hooks.raise outputToken (Reported msg)
 
 cell
   :: forall unusedInput unusedQuery anyMonad

--- a/recipes/NumbersHalogenHooks/src/Main.purs
+++ b/recipes/NumbersHalogenHooks/src/Main.purs
@@ -31,9 +31,9 @@ hookComponent = Hooks.component \_ _ -> Hooks.do
     HH.div_
       [ HH.h1_ [ HH.text $ show roll ]
       , HH.button
-        [ HE.onClick \_ -> do
-            nextRoll <- liftEffect $ randomInt 1 6
-            Hooks.put rollIdx nextRoll
-        ]
-        [ HH.text "Roll" ]
+          [ HE.onClick \_ -> do
+              nextRoll <- liftEffect $ randomInt 1 6
+              Hooks.put rollIdx nextRoll
+          ]
+          [ HH.text "Roll" ]
       ]

--- a/recipes/NumbersReactHooks/src/Main.purs
+++ b/recipes/NumbersReactHooks/src/Main.purs
@@ -1,6 +1,7 @@
 module NumbersReactHooks.Main where
 
 import Prelude
+
 import Data.Maybe (Maybe(..))
 import Effect (Effect)
 import Effect.Exception (throw)

--- a/recipes/ParallelAppMExampleLog/src/AppM.purs
+++ b/recipes/ParallelAppMExampleLog/src/AppM.purs
@@ -1,7 +1,8 @@
 -- | This module demonstrates how to implement a `Parallel` instance
 -- | correctly for a `ReaderT r Aff`-based `AppM` Monad
 module ParallelAppMExampleLog.AppM
-  ( AppM(..), runAppM
+  ( AppM(..)
+  , runAppM
   -- Don't forget to export ParAppM!
   -- Otherwise, you get an unhelpful Type Class Constraint error
   , ParAppM(..)

--- a/recipes/ParallelAppMExampleLog/src/Main.purs
+++ b/recipes/ParallelAppMExampleLog/src/Main.purs
@@ -2,8 +2,8 @@ module ParallelAppMExampleLog.Main where
 
 import Prelude
 
-import Control.Parallel (class Parallel)
 import Control.Monad.Reader (class MonadAsk, ReaderT, asks, runReaderT)
+import Control.Parallel (class Parallel)
 import Data.Unfoldable (range)
 import Effect (Effect)
 import Effect.Aff (Aff, ParAff, parallel, sequential)
@@ -17,49 +17,50 @@ array = map show $ range 1 10
 
 main :: Effect Unit
 main = pure unit
-  -- -- Starts running a computation and blocks until it finishes.
-  -- let runComputation computationName computation = do
-  --       liftEffect $ log $ "Running computation in 1 second: " <> computationName
-  --       delay (Milliseconds 1000.0)
-  --       computation
-  --
-  -- in launchAff_ do
-  --   runComputation "print all items in array sequentially" do
-  --     for_ array \element -> do
-  --       liftEffect $ log element
-  --
-  --   let delayComputationWithRandomAmount = do
-  --         delayAmount <- liftEffect $ randomInt 20 600
-  --         delay $ Milliseconds $ toNumber delayAmount
-  --
-  --   runComputation "print all items in array in parallel" do
-  --     sequential $ for_ array \element -> do
-  --       -- slow down speed of computation based on some random value
-  --       -- to show that things are working in parallel.
-  --       parallel do
-  --         delayComputationWithRandomAmount
-  --         liftEffect $ log element
-  --
-  --   -- same computation as before but with less boilerplate.
-  --   runComputation "print all items in array in parallel using parTraverse" do
-  --     array # parTraverse_ \element -> do
-  --       delayComputationWithRandomAmount
-  --       liftEffect $ log element
-  --
-  --   runComputation "race multiple computations & stop all others when one finishes" do
-  --     let
-  --       -- same as before
-  --       arrayComputation index = do
-  --         let shownIndex = "Array " <> show index <> ": "
-  --         array # traverse \element -> do
-  --           delayComputationWithRandomAmount
-  --           liftEffect $ log $ shownIndex <> element
-  --
-  --     void $ parOneOf [ arrayComputation 1
-  --                     , arrayComputation 2
-  --                     , arrayComputation 3
-  --                     , arrayComputation 4
-  --                     ]
+
+-- -- Starts running a computation and blocks until it finishes.
+-- let runComputation computationName computation = do
+--       liftEffect $ log $ "Running computation in 1 second: " <> computationName
+--       delay (Milliseconds 1000.0)
+--       computation
+--
+-- in launchAff_ do
+--   runComputation "print all items in array sequentially" do
+--     for_ array \element -> do
+--       liftEffect $ log element
+--
+--   let delayComputationWithRandomAmount = do
+--         delayAmount <- liftEffect $ randomInt 20 600
+--         delay $ Milliseconds $ toNumber delayAmount
+--
+--   runComputation "print all items in array in parallel" do
+--     sequential $ for_ array \element -> do
+--       -- slow down speed of computation based on some random value
+--       -- to show that things are working in parallel.
+--       parallel do
+--         delayComputationWithRandomAmount
+--         liftEffect $ log element
+--
+--   -- same computation as before but with less boilerplate.
+--   runComputation "print all items in array in parallel using parTraverse" do
+--     array # parTraverse_ \element -> do
+--       delayComputationWithRandomAmount
+--       liftEffect $ log element
+--
+--   runComputation "race multiple computations & stop all others when one finishes" do
+--     let
+--       -- same as before
+--       arrayComputation index = do
+--         let shownIndex = "Array " <> show index <> ": "
+--         array # traverse \element -> do
+--           delayComputationWithRandomAmount
+--           liftEffect $ log $ shownIndex <> element
+--
+--     void $ parOneOf [ arrayComputation 1
+--                     , arrayComputation 2
+--                     , arrayComputation 3
+--                     , arrayComputation 4
+--                     ]
 
 -- Everything below this line is a copy of
 -- the `AppM.purs` file (excluding imports)

--- a/recipes/PositionsHalogenHooks/src/Main.purs
+++ b/recipes/PositionsHalogenHooks/src/Main.purs
@@ -2,7 +2,7 @@ module PositionsHalogenHooks.Main where
 
 import Prelude hiding (top)
 
-import CSS (position, absolute, top, left, px)
+import CSS (absolute, left, position, px, top)
 import Data.Int (toNumber)
 import Data.Maybe (Maybe(..))
 import Data.Tuple.Nested ((/\))

--- a/recipes/PositionsReactHooks/src/Main.purs
+++ b/recipes/PositionsReactHooks/src/Main.purs
@@ -1,6 +1,7 @@
 module PositionsReactHooks.Main where
 
 import Prelude
+
 import Data.Maybe (Maybe(..))
 import Effect (Effect)
 import Effect.Exception (throw)

--- a/recipes/RandomNumberGameNode/src/Main.purs
+++ b/recipes/RandomNumberGameNode/src/Main.purs
@@ -51,14 +51,16 @@ class (Monad m) <= GameCapabilities m where
   storeGuess :: Int -> m Unit
 
 -- Game logic using only the above capabilities
-game :: forall m.
-        GameCapabilities m =>
-        m Unit
+game
+  :: forall m
+   . GameCapabilities m
+  => m Unit
 game = do
   remaining <- getRemainingGuesses
   notifyUser $ i "Guess the random number. It's between 1 and 10. You have "
-                 (remaining + 1) " guesses. Enter 'q' to quit. \
-                 \Invalid inputs will not count against you."
+    (remaining + 1)
+    " guesses. Enter 'q' to quit. \
+    \Invalid inputs will not count against you."
 
   result <- gameLoop
 
@@ -79,8 +81,10 @@ game = do
 gameLoop :: forall m. GameCapabilities m => m GameResult
 gameLoop = do
   prev <- getPreviousGuesses
-  notifyUser $ i "\n\
-                 \Prevous guesses: " (show prev)
+  notifyUser $ i
+    "\n\
+    \Prevous guesses: "
+    (show prev)
   nextInput <- getUserInput "Guess a number between 1 - 10: "
   case nextInput of
     "q" -> pure PlayerQuits
@@ -93,8 +97,9 @@ gameLoop = do
             notifyUser $ i guess " was not between 1 and 10. Try again."
             gameLoop
         | elem guess prev -> do
-            notifyUser $ i "You already guessed " guess " previously. \
-                           \Please guess a different number."
+            notifyUser $ i "You already guessed " guess
+              " previously. \
+              \Please guess a different number."
             gameLoop
         | otherwise -> do
             answer <- getRandomNumber
@@ -116,11 +121,12 @@ data GameResult
 
 -- ReaderT Design Pattern
 
-type Environment = { randomNumber :: Int
-                   , interface :: Interface
-                   , remainingGuesses :: Ref Int
-                   , previousGuesses :: Ref (Array Int)
-                   }
+type Environment =
+  { randomNumber :: Int
+  , interface :: Interface
+  , remainingGuesses :: Ref Int
+  , previousGuesses :: Ref (Array Int)
+  }
 
 newtype AppM a = AppM (ReaderT Environment Aff a)
 

--- a/recipes/RoutingHashLog/src/Main.purs
+++ b/recipes/RoutingHashLog/src/Main.purs
@@ -1,6 +1,7 @@
 module RoutingHashLog.Main where
 
 import Prelude
+
 import Effect (Effect)
 import RoutingHashLog.MyRouting (logRoute)
 

--- a/recipes/RoutingHashLog/src/Routing.purs
+++ b/recipes/RoutingHashLog/src/Routing.purs
@@ -1,6 +1,7 @@
 module RoutingHashLog.MyRouting where
 
 import Prelude
+
 import Data.Foldable (oneOf)
 import Data.Generic.Rep (class Generic)
 import Data.Show.Generic (genericShow)
@@ -9,8 +10,7 @@ import Effect.Class.Console (log)
 import Routing.Hash (matches)
 import Routing.Match (Match, int, lit, str)
 
-type PostId
-  = Int
+type PostId = Int
 
 data MyRoute
   = PostIndex
@@ -27,11 +27,11 @@ myRoute :: Match MyRoute
 myRoute =
   lit "posts"
     *> oneOf
-        [ PostEdit <$> int <* lit "edit"
-        , Post <$> int
-        , PostBrowse <$> (lit "browse" *> int) <*> str
-        , pure PostIndex -- Unmatched goes to index too
-        ]
+      [ PostEdit <$> int <* lit "edit"
+      , Post <$> int
+      , PostBrowse <$> (lit "browse" *> int) <*> str
+      , pure PostIndex -- Unmatched goes to index too
+      ]
 
 logRoute :: Effect (Effect Unit)
 logRoute =

--- a/recipes/RoutingHashReactHooks/src/Main.purs
+++ b/recipes/RoutingHashReactHooks/src/Main.purs
@@ -1,6 +1,7 @@
 module RoutingHashReactHooks.Main where
 
 import Prelude
+
 import Data.Array as Array
 import Data.Foldable as Foldable
 import Data.Maybe (Maybe(..))
@@ -80,13 +81,13 @@ mkPostIndex =
   postLinks =
     Array.range 1 10
       <#> \n ->
-          R.li_
-            [ R.a
-                { href: "#/posts/" <> show n
-                , children:
-                    [ R.text ("Post " <> show n) ]
-                }
-            ]
+        R.li_
+          [ R.a
+              { href: "#/posts/" <> show n
+              , children:
+                  [ R.text ("Post " <> show n) ]
+              }
+          ]
 
 mkPost :: Component Int
 mkPost =
@@ -125,8 +126,8 @@ appRoute =
   postRoute =
     Match.root *> Match.lit "posts"
       *> Foldable.oneOf
-          [ PostEdit <$> Match.int <* Match.lit "edit"
-          , Post <$> Match.int
-          , pure PostIndex
-          ]
+        [ PostEdit <$> Match.int <* Match.lit "edit"
+        , Post <$> Match.int
+        , pure PostIndex
+        ]
       <* Match.end

--- a/recipes/RunCapabilityPatternNode/src/Application.purs
+++ b/recipes/RunCapabilityPatternNode/src/Application.purs
@@ -24,14 +24,13 @@ getUserName = Run.lift _getUserName $ GetUserName identity
 -- | A program which makes us of the dsls we defined earlier.
 program :: forall r. Run (LOGGER + GET_USER_NAME + r) String
 program = do
-    log "what is your name?"
-    name <- getUserName
-    log $ "Your name is " <> getName name
-    pure $ getName name
+  log "what is your name?"
+  name <- getUserName
+  log $ "Your name is " <> getName name
+  pure $ getName name
 
 -- Free monads increase the boilerplate for defining the dsls 
 -- but greatly reduce the boilerplate needed for writing different interpreters
-
 
 derive instance loggerFunctor :: Functor LoggerF
 derive instance getUserNameFunctor :: Functor GetUserNameF

--- a/recipes/RunCapabilityPatternNode/src/Main.purs
+++ b/recipes/RunCapabilityPatternNode/src/Main.purs
@@ -3,8 +3,8 @@ module RunCapabilityPatternNode.Main where
 import Prelude
 
 import App.Application (program)
-import App.Production.Async (Environment,  runApp) as Async
-import App.Production.Sync (Environment,  runApp) as Sync
+import App.Production.Async (Environment, runApp) as Async
+import App.Production.Sync (Environment, runApp) as Sync
 import App.Test (Environment, runApp) as Test
 import Effect (Effect)
 import Effect.Aff (launchAff_)
@@ -29,7 +29,8 @@ mainTest :: Test.Environment -> Effect Unit
 mainTest _ = do
   assert $ (Test.runApp program) == "succeeds"
   log "first test succeeded, now a failing test which will crash"
-  -- assert $ (Test.runApp program) == "failing test"
+
+-- assert $ (Test.runApp program) == "failing test"
 
 mainAff1 :: Async.Environment -> Effect Unit
 mainAff1 env = launchAff_ $ void $ Async.runApp env program

--- a/recipes/RunCapabilityPatternNode/src/ProductionAsync.purs
+++ b/recipes/RunCapabilityPatternNode/src/ProductionAsync.purs
@@ -1,4 +1,5 @@
 module App.Production.Async where
+
 -- Layer 1 & 2. You can split these in 2 different files if you feel the need to.
 
 import Prelude

--- a/recipes/RunCapabilityPatternNode/src/ProductionSync.purs
+++ b/recipes/RunCapabilityPatternNode/src/ProductionSync.purs
@@ -1,9 +1,10 @@
 module App.Production.Sync where
+
 -- Layer 1 & 2. You can split these in 2 different files if you feel the need to.
 
 import Prelude
 
-import App.Application (GetUserNameF(..), LOGGER, LoggerF(..), GET_USER_NAME, _getUserName, _logger)
+import App.Application (GET_USER_NAME, GetUserNameF(..), LOGGER, LoggerF(..), _getUserName, _logger)
 import App.Types (Name(..))
 import Effect (Effect)
 import Effect.Class (liftEffect)
@@ -25,7 +26,7 @@ runApp env = runLogger >>> runGetUserName env >>> runBaseEffect
 runLogger :: forall r. AppM (LOGGER + r) ~> AppM r
 runLogger = Run.interpret (on _logger handleLogger send)
   where
-  handleLogger :: LoggerF ~> AppM r 
+  handleLogger :: LoggerF ~> AppM r
   handleLogger (Log message a) = log message $> a
 
 runGetUserName :: forall r. Environment -> AppM (GET_USER_NAME + r) ~> AppM r

--- a/recipes/RunCapabilityPatternNode/src/Test.purs
+++ b/recipes/RunCapabilityPatternNode/src/Test.purs
@@ -1,9 +1,10 @@
 module App.Test where
+
 -- Layer 1 & 2. You can split these in 2 different files if you feel the need to.
 
 import Prelude
 
-import App.Application (GetUserNameF(..), LOGGER, LoggerF(..), GET_USER_NAME, _getUserName, _logger)
+import App.Application (GET_USER_NAME, GetUserNameF(..), LOGGER, LoggerF(..), _getUserName, _logger)
 import App.Types (Name(..))
 import Run (Run, extract, on, send)
 import Run as Run
@@ -16,12 +17,12 @@ type TestM r = Run r
 
 -- | Running our monad is just a matter of interpreter composition.
 runApp :: forall a. TestM (LOGGER + GET_USER_NAME + ()) a -> a
-runApp = runLogger >>> runGetUserName  >>> extract
+runApp = runLogger >>> runGetUserName >>> extract
 
 runLogger :: forall r. TestM (LOGGER + r) ~> TestM r
 runLogger = Run.interpret (on _logger handleLogger send)
   where
-  handleLogger :: LoggerF ~> TestM r 
+  handleLogger :: LoggerF ~> TestM r
   handleLogger (Log _ a) = pure a
 
 runGetUserName :: forall r. TestM (GET_USER_NAME + r) ~> TestM r

--- a/recipes/RunCapabilityPatternNode/src/Types.purs
+++ b/recipes/RunCapabilityPatternNode/src/Types.purs
@@ -7,7 +7,6 @@ newtype Name = Name String
 getName :: Name -> String
 getName (Name s) = s
 
-
 -- NB this is the smallest file in this skeletal example
 -- but if you can you'd like to have as much of your code
 -- as you possibly can in this Layer!!

--- a/recipes/ShapesHalogenHooks/src/Main.purs
+++ b/recipes/ShapesHalogenHooks/src/Main.purs
@@ -1,18 +1,44 @@
 module ShapesHalogenHooks.Main where
 
 import Prelude
+
 import Data.Maybe (Maybe(..))
 import Effect (Effect)
 import Halogen as H
 import Halogen.Aff as HA
-import Halogen.Hooks as Hooks
 import Halogen.HTML as HH
+import Halogen.Hooks as Hooks
+import Halogen.Svg.Attributes
+  ( Baseline(Central)
+  , Color(RGB)
+  , CommandPositionReference(Abs)
+  , TextAnchor(AnchorMiddle)
+  , Transform(Rotate)
+  , cx
+  , cy
+  , d
+  , dominantBaseline
+  , fill
+  , height
+  , l
+  , m
+  , r
+  , stroke
+  , strokeWidth
+  , textAnchor
+  , transform
+  , viewBox
+  , width
+  , x
+  , x1
+  , x2
+  , y
+  , y1
+  , y2
+  )
+import Halogen.Svg.Elements (circle, line, path, rect, svg, text)
 import Halogen.VDom.Driver (runUI)
-import Halogen.Svg.Elements (svg, circle, line, path, rect, text)
-import Halogen.Svg.Attributes (cx, cy, d, dominantBaseline, fill, height, r,
-  stroke, strokeWidth, textAnchor, transform, viewBox, width, x, x1, x2, y, y1,
-  y2, CommandPositionReference(Abs), m, l, Color(RGB), TextAnchor(AnchorMiddle),
-  Baseline(Central), Transform(Rotate))
+
 {- We import a lot of functions from Halogen.Svg.Attributes which makes the SVG
    code below cleaner. You may prefer to import with
       `import Halogen.Svg.Attributes as SA`
@@ -25,9 +51,9 @@ main =
     body <- HA.awaitBody
     void $ runUI hookComponent Nothing body
 
-hookComponent ::
-  forall unusedQuery unusedInput unusedOutput anyMonad.
-  H.Component unusedQuery unusedInput unusedOutput anyMonad
+hookComponent
+  :: forall unusedQuery unusedInput unusedOutput anyMonad
+   . H.Component unusedQuery unusedInput unusedOutput anyMonad
 hookComponent =
   Hooks.component \_ _ ->
     Hooks.pure

--- a/recipes/ShapesReactHooks/src/Main.purs
+++ b/recipes/ShapesReactHooks/src/Main.purs
@@ -1,6 +1,7 @@
 module ShapesReactHooks.Main where
 
 import Prelude
+
 import Data.Maybe (Maybe(..))
 import Effect (Effect)
 import Effect.Exception (throw)

--- a/recipes/SignalRenderJs/src/Main.purs
+++ b/recipes/SignalRenderJs/src/Main.purs
@@ -22,13 +22,13 @@ import Web.HTML.Window (document)
 -- Model is the type of our application state.
 -- We track a direction to move on each tick,
 -- and our position.
-type Model
-  = { direction :: Direction
-    , pos :: Int
-    }
+type Model =
+  { direction :: Direction
+  , pos :: Int
+  }
 
 initialState :: Model
-initialState = {pos: 0, direction: Right}
+initialState = { pos: 0, direction: Right }
 
 data Direction
   = Left
@@ -51,12 +51,12 @@ data Action
 -- How we update our model with each Action.
 -- For example changing direction or moving a step.
 update :: Action -> Model -> Model
-update (SetDir d) m = m {direction = d}
+update (SetDir d) m = m { direction = d }
 update Tick m = m { pos = m.pos + step m.direction }
   where
-    step :: Direction -> Int
-    step Left = -1
-    step Right = 1
+  step :: Direction -> Int
+  step Left = -1
+  step Right = 1
 
 -- RENDERING
 --

--- a/recipes/SignalSnakeJs/src/Main.purs
+++ b/recipes/SignalSnakeJs/src/Main.purs
@@ -58,10 +58,10 @@ wallColor = rgb 0 128 0
 
 -- STATE MODEL AND TYPES
 --
-type Point
-  = { x :: Int
-    , y :: Int
-    }
+type Point =
+  { x :: Int
+  , y :: Int
+  }
 
 -- Convenience function for creating points
 p :: Int -> Int -> Point
@@ -75,16 +75,15 @@ data Direction
 
 derive instance eqDirection :: Eq Direction
 
-type Snake
-  = NonEmptyArray Point
+type Snake = NonEmptyArray Point
 
 -- The type of our game state
-type Model
-  = { food :: Point
-    , snake :: Snake
-    , direction :: Direction
-    , genState :: GenState
-    }
+type Model =
+  { food :: Point
+  , snake :: Snake
+  , direction :: Direction
+  , genState :: GenState
+  }
 
 -- Some initial state values
 initialDirection :: Direction
@@ -247,9 +246,9 @@ sigArrowsEff = do
   -- * Wraps in an Effect
   pure $ SetDir
     <$> mapKey Left left
-    <> mapKey Right right
-    <> mapKey Up up
-    <> mapKey Down down
+      <> mapKey Right right
+      <> mapKey Up up
+      <> mapKey Down down
 
 {- Note that this strategy for merging signals only considers the
 most recent start of a keypress to determine a single key that

--- a/recipes/SignalTrisJs/src/Main.purs
+++ b/recipes/SignalTrisJs/src/Main.purs
@@ -97,8 +97,7 @@ initialOffset = { x: width / 2 - 1, y: 0 }
 
 -- STATE MODEL AND TYPES
 --
-type Point
-  = { x :: Int, y :: Int }
+type Point = { x :: Int, y :: Int }
 
 data Direction
   = Left
@@ -108,28 +107,27 @@ data Direction
 
 derive instance eqDirection :: Eq Direction
 
-type Board
-  = Map Point Color
+type Board = Map Point Color
 
-type Tile
-  = { cells :: Set Point
-    , color :: Color
-    }
+type Tile =
+  { cells :: Set Point
+  , color :: Color
+  }
 
-type ActiveTile
-  = { tile :: Tile
-    , offset :: Point
-    }
+type ActiveTile =
+  { tile :: Tile
+  , offset :: Point
+  }
 
-type Model
-  = { activeTile :: ActiveTile
-    , nextTile :: Tile
-    , board :: Board
-    , score :: Int
-    , frameCounter :: Int
-    , status :: Status
-    , genState :: GenState
-    }
+type Model =
+  { activeTile :: ActiveTile
+  , nextTile :: Tile
+  , board :: Board
+  , score :: Int
+  , frameCounter :: Int
+  , status :: Status
+  , genState :: GenState
+  }
 
 data Status
   = GameOver
@@ -273,10 +271,10 @@ An improved algorithm would:
   * Perform board remapping on single pass
 But this is not a big performance issue for tiny boards, so leaving as-is for now.
 -}
-type BoardAndScore
-  = { board :: Board
-    , score :: Int
-    }
+type BoardAndScore =
+  { board :: Board
+  , score :: Int
+  }
 
 flushBoard :: BoardAndScore -> BoardAndScore
 flushBoard = foldl (>>>) identity (map flushRow (2 .. (height - 1)))
@@ -387,10 +385,12 @@ drawCell ctx { x, y } color = do
 --
 -- A wrapper for `rect` that accepts a `Rectangle` where the fields
 -- are `Int` rather than `Number`.
-rectInt ::
-  forall intRect.
-  HMap (Int -> Number) intRect Rectangle =>
-  Context2D -> intRect -> Effect Unit
+rectInt
+  :: forall intRect
+   . HMap (Int -> Number) intRect Rectangle
+  => Context2D
+  -> intRect
+  -> Effect Unit
 rectInt ctx r = rect ctx $ hmap toNumber r
 
 -- Wrapper with Int, rather than Number params
@@ -426,9 +426,9 @@ sigArrowsEff = do
   -- * Wraps in an Effect
   pure $ Move
     <$> mapKeypress Left left
-    <> mapKeypress Right right
-    <> mapKeypress Rotate up
-    <> mapKeypress Down down
+      <> mapKeypress Right right
+      <> mapKeypress Rotate up
+      <> mapKeypress Down down
 
 -- Convert a keypress (bool) signal to a Direction signal.
 -- Note that Signals must always have a value, so aritrarily

--- a/recipes/TextFieldsHalogenHooks/src/Main.purs
+++ b/recipes/TextFieldsHalogenHooks/src/Main.purs
@@ -29,10 +29,10 @@ hookComponent = Hooks.component \_ _ -> Hooks.do
   Hooks.pure $
     HH.div_
       [ HH.input
-        [ HP.placeholder "Text to reverse"
-        , HP.value state
-        , HE.onValueInput \newValue -> Hooks.put stateIdx newValue
-        ]
+          [ HP.placeholder "Text to reverse"
+          , HP.value state
+          , HE.onValueInput \newValue -> Hooks.put stateIdx newValue
+          ]
       , HH.div_ [ HH.text $ reverse state ]
       ]
 

--- a/recipes/TextFieldsReactHooks/src/Main.purs
+++ b/recipes/TextFieldsReactHooks/src/Main.purs
@@ -1,6 +1,7 @@
 module TextFieldsReactHooks.Main where
 
 import Prelude
+
 import Data.Array as Array
 import Data.Maybe (Maybe(..), fromMaybe)
 import Data.String (fromCodePointArray, toCodePointArray)

--- a/recipes/TicTacToeReactHooks/src/Main.purs
+++ b/recipes/TicTacToeReactHooks/src/Main.purs
@@ -7,12 +7,12 @@ import Data.Array (concat, (:))
 import Data.Array as Array
 import Data.Array.NonEmpty (NonEmptyArray)
 import Data.Array.NonEmpty as NonEmpty
+import Data.Eq.Generic (genericEq)
 import Data.Foldable (or)
 import Data.Generic.Rep (class Generic)
-import Data.Eq.Generic (genericEq)
-import Data.Show.Generic (genericShow)
 import Data.Int (even)
 import Data.Maybe (Maybe(..), fromMaybe, isJust)
+import Data.Show.Generic (genericShow)
 import Effect (Effect)
 import Effect.Exception (throw)
 import React.Basic.DOM (CSS, css, render)
@@ -49,8 +49,7 @@ mkSquare =
           , children: [ R.text text ]
           }
 
-type Square
-  = Maybe Player
+type Square = Maybe Player
 
 data Player
   = X
@@ -64,11 +63,11 @@ instance showPlayer :: Show Player where
 instance eqPlayer :: Eq Player where
   eq = genericEq
 
-mkBoard ::
-  Component
-    { onClick :: Int -> Int -> EventHandler
-    , squares :: BoardState
-    }
+mkBoard
+  :: Component
+       { onClick :: Int -> Int -> EventHandler
+       , squares :: BoardState
+       }
 mkBoard = do
   square <- mkSquare
   component "Board" \props -> React.do
@@ -94,14 +93,13 @@ data Action
   = JumpToStep Int
   | FillSquare Int Int
 
-type BoardState
-  = Int -> Int -> Square
+type BoardState = Int -> Int -> Square
 
-type State
-  = { history :: NonEmptyArray BoardState
-    , stepNumber :: Int
-    , xIsNext :: Boolean
-    }
+type State =
+  { history :: NonEmptyArray BoardState
+  , stepNumber :: Int
+  , xIsNext :: Boolean
+  }
 
 reducerFn :: Effect (Reducer State Action)
 reducerFn =
@@ -204,19 +202,18 @@ calculateWinner f =
   let
     winByPlayer :: Player -> Maybe Player
     winByPlayer p =
-      if 
-      -- Check for a row full of player 'p'
-      [ [ 0, 1, 2 ] <#> \i -> [ 0, 1, 2 ] <#> \j -> f i j
-      -- Check for a full column
-      , [ 0, 1, 2 ] <#> \j -> [ 0, 1, 2 ] <#> \i -> f i j
-      -- Check diagonals
-      , [ [ 0, 1, 2 ] <#> \k -> f k k ]
-      , [ [ 0, 1, 2 ] <#> \k -> f k (2 - k) ]
-      ]
-        # concat
-        >>> map (Array.all (_ == Just p))
-        >>> or
-      then
+      if
+        -- Check for a row full of player 'p'
+        [ [ 0, 1, 2 ] <#> \i -> [ 0, 1, 2 ] <#> \j -> f i j
+        -- Check for a full column
+        , [ 0, 1, 2 ] <#> \j -> [ 0, 1, 2 ] <#> \i -> f i j
+        -- Check diagonals
+        , [ [ 0, 1, 2 ] <#> \k -> f k k ]
+        , [ [ 0, 1, 2 ] <#> \k -> f k (2 - k) ]
+        ]
+          # concat
+              >>> map (Array.all (_ == Just p))
+              >>> or then
         Just p
       else
         Nothing
@@ -225,13 +222,13 @@ calculateWinner f =
 
 -- These styles could be provided by a proper stylesheet, we are only
 -- defining them here for the sake of compatibility with TryPureScript
-styles ::
-  { list :: CSS
-  , boardRow :: CSS
-  , square :: CSS
-  , game :: CSS
-  , gameInfo :: CSS
-  }
+styles
+  :: { list :: CSS
+     , boardRow :: CSS
+     , square :: CSS
+     , game :: CSS
+     , gameInfo :: CSS
+     }
 styles =
   { list:
       css

--- a/recipes/TimeReactHooks/src/Main.purs
+++ b/recipes/TimeReactHooks/src/Main.purs
@@ -1,6 +1,7 @@
 module TimeReactHooks.Main where
 
 import Prelude
+
 import Data.Array (intercalate)
 import Data.Int (floor)
 import Data.JSDate (JSDate)
@@ -19,8 +20,7 @@ import Web.HTML.HTMLDocument (body)
 import Web.HTML.HTMLElement (toElement)
 import Web.HTML.Window (document)
 
-type Time
-  = { hours :: Int, minutes :: Int, seconds :: Int }
+type Time = { hours :: Int, minutes :: Int, seconds :: Int }
 
 main :: Effect Unit
 main = do
@@ -46,8 +46,7 @@ mkTime = do
                   ]
           ]
 
-newtype UseCurrentTime hooks
-  = UseCurrentTime (UseEffect Unit (UseState Time hooks))
+newtype UseCurrentTime hooks = UseCurrentTime (UseEffect Unit (UseState Time hooks))
 
 derive instance ntUseCurrentTime :: Newtype (UseCurrentTime hooks) _
 

--- a/recipes/ValueBasedJsonCodecLog/src/Main.purs
+++ b/recipes/ValueBasedJsonCodecLog/src/Main.purs
@@ -125,9 +125,10 @@ entireRecordCodec =
           encode :: IntBooleanString -> { key1 :: Int, key2 :: Boolean, key3 :: String }
           encode (IntBooleanString i b s) = { key1: i, key2: b, key3: s }
 
-          decode :: { key1 :: Int, key2 :: Boolean, key3 :: String }
-                 -> IntBooleanString
-          decode {key1, key2, key3} = (IntBooleanString key1 key2 key3)
+          decode
+            :: { key1 :: Int, key2 :: Boolean, key3 :: String }
+            -> IntBooleanString
+          decode { key1, key2, key3 } = (IntBooleanString key1 key2 key3)
 
         dimap encode decode $ CAR.object "productTypesWithLabels"
           { key1: CA.int
@@ -136,41 +137,41 @@ entireRecordCodec =
           }
     }
   where
-    sumTypesNoTags :: JsonCodec (Array (Maybe Int))
-    sumTypesNoTags = basicCodec decodeArray encodeArray
-      where
-        encodeArray :: Array (Maybe Int) -> Json
-        encodeArray arrayMaybeInt = do
-          let arrayOfString = arrayMaybeInt <#> case _ of
-                Nothing -> "Nothing"
-                Just i -> "Just " <> show i
-          encode (CA.array CA.string) arrayOfString
+  sumTypesNoTags :: JsonCodec (Array (Maybe Int))
+  sumTypesNoTags = basicCodec decodeArray encodeArray
+    where
+    encodeArray :: Array (Maybe Int) -> Json
+    encodeArray arrayMaybeInt = do
+      let
+        arrayOfString = arrayMaybeInt <#> case _ of
+          Nothing -> "Nothing"
+          Just i -> "Just " <> show i
+      encode (CA.array CA.string) arrayOfString
 
-        lmapFlipped :: forall f a b c. Bifunctor f => f a c -> (a -> b) -> f b c
-        lmapFlipped = flip lmap
+    lmapFlipped :: forall f a b c. Bifunctor f => f a c -> (a -> b) -> f b c
+    lmapFlipped = flip lmap
 
-        decodeArray :: Json -> Either JsonDecodeError (Array (Maybe Int))
-        decodeArray jsonArray = do
-          arrayOfJson <- decode (CA.array CA.json) jsonArray
-          forWithIndex arrayOfJson \idx jsonValue -> do
-            decodeValue jsonValue `lmapFlipped` \lowerLevelError ->
-              Named "decodeArray" $ Named "forWithIndex" $ AtIndex idx lowerLevelError
+    decodeArray :: Json -> Either JsonDecodeError (Array (Maybe Int))
+    decodeArray jsonArray = do
+      arrayOfJson <- decode (CA.array CA.json) jsonArray
+      forWithIndex arrayOfJson \idx jsonValue -> do
+        decodeValue jsonValue `lmapFlipped` \lowerLevelError ->
+          Named "decodeArray" $ Named "forWithIndex" $ AtIndex idx lowerLevelError
 
-        decodeValue :: Json -> Either JsonDecodeError (Maybe Int)
-        decodeValue jsonValue = do
-          str <- decode CA.string jsonValue
-          case str of
-            "Nothing" -> pure Nothing
-            somethingElse -> case splitAt 5 somethingElse of
-              { before: "Just ", after: intValue } ->
-                case Int.fromString intValue of
-                  Nothing -> Left $ TypeMismatch $
-                              "Expected 'Just <int>', \
-                              \but got 'Just " <> intValue <> "'"
-                  justI -> pure justI
-              _ ->
-                Left $ UnexpectedValue jsonValue
-
+    decodeValue :: Json -> Either JsonDecodeError (Maybe Int)
+    decodeValue jsonValue = do
+      str <- decode CA.string jsonValue
+      case str of
+        "Nothing" -> pure Nothing
+        somethingElse -> case splitAt 5 somethingElse of
+          { before: "Just ", after: intValue } ->
+            case Int.fromString intValue of
+              Nothing -> Left $ TypeMismatch $
+                "Expected 'Just <int>', \
+                \but got 'Just " <> intValue <> "'"
+              justI -> pure justI
+          _ ->
+            Left $ UnexpectedValue jsonValue
 
 exampleValue :: EntireRecord
 exampleValue =
@@ -178,7 +179,7 @@ exampleValue =
   , boolean: true
   , int: 4
   , number: 42.0
-  , array: ["elem 1", "elem 2", "elem 3"]
+  , array: [ "elem 1", "elem 2", "elem 3" ]
   , record: { foo: "bar", baz: 8 }
   , sumTypesNoTags: [ Nothing, Just 1 ]
   , sumTypeWithTags: [ Nothing, Just 1 ]

--- a/recipes/WindowPropertiesJs/src/Main.purs
+++ b/recipes/WindowPropertiesJs/src/Main.purs
@@ -50,9 +50,20 @@ printWindowValues win = do
   currentScrollX <- scrollX win
   currentScrollY <- scrollY win
   log $ i
-    "inner width: "(show currentInnerWidth)"\n\
-    \inner height: "(show currentInnerHeight)"\n\
-    \outer width: "(show currentOuterWidth)"\n\
-    \outer height: "(show currentOuterHeight)"\n\
-    \scroll x: "(show currentScrollX)"\n\
-    \scroll y: "(show currentScrollY)
+    "inner width: "
+    (show currentInnerWidth)
+    "\n\
+    \inner height: "
+    (show currentInnerHeight)
+    "\n\
+    \outer width: "
+    (show currentOuterWidth)
+    "\n\
+    \outer height: "
+    (show currentOuterHeight)
+    "\n\
+    \scroll x: "
+    (show currentScrollX)
+    "\n\
+    \scroll y: "
+    (show currentScrollY)


### PR DESCRIPTION
With the goal of consistent formatting and import order across examples the repository is formatted with `purs-tidy`, a dependency and the configuration are added to the repository. Asked upfront if a change like this makes sense and am open to apply changes to `.tidyrc.json` if they're prefered.

## Changes

* Initial repository formatting (`make format`)
* `make formatCheck` command is added and executed on CI