### PR TITLE
Update 21 react examples to v18

### DIFF
--- a/packages.dhall
+++ b/packages.dhall
@@ -1,6 +1,6 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.15.4-20220723/packages.dhall
-        sha256:efb50561d50d0bebe01f8e5ab21cda51662cca0f5548392bafc3216953a0ed88
+      https://github.com/purescript/package-sets/releases/download/psc-0.15.4-20220808/packages.dhall
+        sha256:60eee64b04ca0013fae3e02a69fc3b176105c6baa2f31865c67cd5f881a412fd
 
 let overrides = {=}
 

--- a/recipes/BookReactHooks/spago.dhall
+++ b/recipes/BookReactHooks/spago.dhall
@@ -10,6 +10,7 @@
   , "react-basic-dom"
   , "react-basic-hooks"
   , "web-html"
+  , "web-dom"
   ]
 , packages = ../../packages.dhall
 , sources = [ "recipes/BookReactHooks/src/**/*.purs" ]

--- a/recipes/BookReactHooks/src/Main.purs
+++ b/recipes/BookReactHooks/src/Main.purs
@@ -9,14 +9,14 @@ import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
 import Effect (Effect)
 import Effect.Exception (throw)
-import React.Basic.DOM (render)
 import React.Basic.DOM as R
+import React.Basic.DOM.Client (createRoot, renderRoot)
 import React.Basic.Hooks (Component, component)
 import React.Basic.Hooks as React
 import React.Basic.Hooks.Aff (useAff)
+import Web.DOM.NonElementParentNode (getElementById)
 import Web.HTML (window)
-import Web.HTML.HTMLDocument (body)
-import Web.HTML.HTMLElement (toElement)
+import Web.HTML.HTMLDocument (toNonElementParentNode)
 import Web.HTML.Window (document)
 
 data TextState
@@ -25,15 +25,17 @@ data TextState
 
 main :: Effect Unit
 main = do
-  body <- body =<< document =<< window
-  case body of
-    Nothing -> throw "Could not find body."
-    Just b -> do
-      bookComponent <- mkBookComponent
-      render (bookComponent {}) (toElement b)
+  doc <- document =<< window
+  root <- getElementById "root" $ toNonElementParentNode doc
+  case root of
+    Nothing -> throw "Could not find root."
+    Just container -> do
+      reactRoot <- createRoot container
+      app <- mkApp
+      renderRoot reactRoot (app {})
 
-mkBookComponent :: Component {}
-mkBookComponent = do
+mkApp :: Component {}
+mkApp = do
   let
     url = "https://elm-lang.org/assets/public-opinion.txt"
   component "Book" \_ -> React.do

--- a/recipes/ButtonsReactHooks/spago.dhall
+++ b/recipes/ButtonsReactHooks/spago.dhall
@@ -7,6 +7,7 @@
   , "react-basic"
   , "react-basic-dom"
   , "react-basic-hooks"
+  , "web-dom"
   , "web-html"
   ]
 , packages = ../../packages.dhall

--- a/recipes/ButtonsReactHooks/src/Main.purs
+++ b/recipes/ButtonsReactHooks/src/Main.purs
@@ -5,34 +5,34 @@ import Prelude
 import Data.Maybe (Maybe(..))
 import Effect (Effect)
 import Effect.Exception (throw)
-import React.Basic.DOM (render)
 import React.Basic.DOM as R
+import React.Basic.DOM.Client (createRoot, renderRoot)
 import React.Basic.Events (handler_)
 import React.Basic.Hooks (Component, component, useState, (/\))
 import React.Basic.Hooks as React
+import Web.DOM.NonElementParentNode (getElementById)
 import Web.HTML (window)
-import Web.HTML.HTMLDocument (body)
-import Web.HTML.HTMLElement (toElement)
+import Web.HTML.HTMLDocument (toNonElementParentNode)
 import Web.HTML.Window (document)
 
 main :: Effect Unit
 main = do
-  body <- body =<< document =<< window
-  case body of
-    Nothing -> throw "Could not find body."
-    Just b -> do
-      buttons <- mkButtons
-      render (buttons {}) (toElement b)
+  doc <- document =<< window
+  root <- getElementById "root" $ toNonElementParentNode doc
+  case root of
+    Nothing -> throw "Could not find root."
+    Just container -> do
+      reactRoot <- createRoot container
+      app <- mkApp
+      renderRoot reactRoot (app {})
 
-mkButtons :: Component {}
-mkButtons = do
+mkApp :: Component {}
+mkApp =
   component "Buttons" \_ -> React.do
     count /\ setCount <- useState 0
-    let
-      handleClick = handler_ <<< setCount
-    pure
-      $ R.div_
-          [ R.button { onClick: handleClick (_ - 1), children: [ R.text "-" ] }
-          , R.div_ [ R.text (show count) ]
-          , R.button { onClick: handleClick (_ + 1), children: [ R.text "+" ] }
-          ]
+    let handleClick = handler_ <<< setCount
+    pure $ R.div_
+      [ R.button { onClick: handleClick (_ - 1), children: [ R.text "-" ] }
+      , R.div_ [ R.text (show count) ]
+      , R.button { onClick: handleClick (_ + 1), children: [ R.text "+" ] }
+      ]

--- a/recipes/CardsReactHooks/spago.dhall
+++ b/recipes/CardsReactHooks/spago.dhall
@@ -9,6 +9,7 @@
   , "react-basic"
   , "react-basic-dom"
   , "react-basic-hooks"
+  , "web-dom"
   , "web-html"
   ]
 , packages = ../../packages.dhall

--- a/recipes/CardsReactHooks/src/Main.purs
+++ b/recipes/CardsReactHooks/src/Main.purs
@@ -6,46 +6,46 @@ import Data.Array.NonEmpty (cons')
 import Data.Maybe (Maybe(..))
 import Effect (Effect)
 import Effect.Exception (throw)
-import React.Basic.DOM (css, render)
+import React.Basic.DOM (css)
 import React.Basic.DOM as R
+import React.Basic.DOM.Client (createRoot, renderRoot)
 import React.Basic.Events (handler_)
 import React.Basic.Hooks (Component, component, useState, (/\))
 import React.Basic.Hooks as React
 import Test.QuickCheck (mkSeed)
 import Test.QuickCheck.Gen (Gen, elements, runGen)
+import Web.DOM.NonElementParentNode (getElementById)
 import Web.HTML (window)
-import Web.HTML.HTMLDocument (body)
-import Web.HTML.HTMLElement (toElement)
+import Web.HTML.HTMLDocument (toNonElementParentNode)
 import Web.HTML.Window (document)
 
 main :: Effect Unit
 main = do
-  body <- body =<< document =<< window
-  case body of
-    Nothing -> throw "Could not find body."
-    Just b -> do
-      cardsComponent <- mkCardsComponent
-      render (cardsComponent {}) (toElement b)
+  doc <- document =<< window
+  root <- getElementById "root" $ toNonElementParentNode doc
+  case root of
+    Nothing -> throw "Could not find root."
+    Just container -> do
+      reactRoot <- createRoot container
+      app <- mkApp
+      renderRoot reactRoot (app {})
 
-mkCardsComponent :: Component {}
-mkCardsComponent = do
-  let
-    initialGenState = { newSeed: mkSeed 3, size: 1 }
+mkApp :: Component {}
+mkApp = do
+  let initialGenState = { newSeed: mkSeed 3, size: 1 }
   component "Cards" \_ -> React.do
     -- "Card state" is a tuple of the card and generator state.
     -- We don't need the actual generator state for rendering, so we're ignoring it with `_`.
     (card /\ _) /\ setCardState <- useState (runGen cardGenerator initialGenState)
     let
-      onClick =
-        handler_ do
-          -- Modify the card generator state by re-running the generator.
-          -- We don't need the card value for this update function, so it is ignored with `_`.
-          setCardState \(_ /\ genState) -> runGen cardGenerator genState
-    pure
-      $ R.div_
-          [ R.button { onClick, children: [ R.text "Draw" ] }
-          , R.div { style: css { fontSize: "12em" }, children: [ R.text (viewCard card) ] }
-          ]
+      onClick = handler_ do
+        -- Modify the card generator state by re-running the generator.
+        -- We don't need the card value for this update function, so it is ignored with `_`.
+        setCardState \(_ /\ genState) -> runGen cardGenerator genState
+    pure $ R.div_
+      [ R.button { onClick, children: [ R.text "Draw" ] }
+      , R.div { style: css { fontSize: "12em" }, children: [ R.text (viewCard card) ] }
+      ]
 
 data Card
   = Ace
@@ -63,22 +63,21 @@ data Card
   | King
 
 cardGenerator :: Gen Card
-cardGenerator =
-  elements
-    $ cons' Ace
-        [ Two
-        , Three
-        , Four
-        , Five
-        , Six
-        , Seven
-        , Eight
-        , Nine
-        , Ten
-        , Jack
-        , Queen
-        , King
-        ]
+cardGenerator = elements $
+  cons' Ace
+    [ Two
+    , Three
+    , Four
+    , Five
+    , Six
+    , Seven
+    , Eight
+    , Nine
+    , Ten
+    , Jack
+    , Queen
+    , King
+    ]
 
 viewCard :: Card -> String
 viewCard = case _ of

--- a/recipes/CatGifsReactHooks/spago.dhall
+++ b/recipes/CatGifsReactHooks/spago.dhall
@@ -12,6 +12,7 @@
   , "react-basic"
   , "react-basic-dom"
   , "react-basic-hooks"
+  , "web-dom"
   , "web-html"
   ]
 , packages = ../../packages.dhall

--- a/recipes/CatGifsReactHooks/src/Main.purs
+++ b/recipes/CatGifsReactHooks/src/Main.purs
@@ -11,16 +11,17 @@ import Data.Maybe (Maybe(..), maybe)
 import Effect (Effect)
 import Effect.Aff (Aff)
 import Effect.Exception (throw)
-import React.Basic.DOM (css, render)
+import React.Basic.DOM (css)
 import React.Basic.DOM as R
+import React.Basic.DOM.Client (createRoot, renderRoot)
 import React.Basic.Events (handler_)
 import React.Basic.Hooks (Component, component, (/\))
 import React.Basic.Hooks as React
 import React.Basic.Hooks.Aff (useAff)
 import React.Basic.Hooks.ResetToken (useResetToken)
+import Web.DOM.NonElementParentNode (getElementById)
 import Web.HTML (window)
-import Web.HTML.HTMLDocument (body)
-import Web.HTML.HTMLElement (toElement)
+import Web.HTML.HTMLDocument (toNonElementParentNode)
 import Web.HTML.Window (document)
 
 data GifState
@@ -30,20 +31,21 @@ data GifState
 
 main :: Effect Unit
 main = do
-  body <- body =<< document =<< window
-  case body of
-    Nothing -> throw "Could not find body."
-    Just b -> do
-      catGifs <- mkCatGifs
-      render (catGifs {}) (toElement b)
+  doc <- document =<< window
+  root <- getElementById "root" $ toNonElementParentNode doc
+  case root of
+    Nothing -> throw "Could not find root."
+    Just container -> do
+      reactRoot <- createRoot container
+      app <- mkApp
+      renderRoot reactRoot (app {})
 
-mkCatGifs :: Component {}
-mkCatGifs = do
+mkApp :: Component {}
+mkApp = do
   component "CatGifs" \_ -> React.do
     (resetToken /\ reset) <- useResetToken
     gifState <- toGifState <$> useAff resetToken getRandomCatGif
-    let
-      onClick = handler_ reset
+    let onClick = handler_ reset
     pure
       $ R.div_
           [ R.h2_ [ R.text "Random Cats" ]
@@ -51,12 +53,16 @@ mkCatGifs = do
               Loading -> R.text "Loading..."
               Failure ->
                 R.div_
-                  [ R.text "I could not load a random cat for some reason. "
+                  [ R.text "I could not load a random cat for some reason."
                   , R.button { onClick, children: [ R.text "Try Again!" ] }
                   ]
               Success url ->
                 R.div_
-                  [ R.button { onClick, style: css { display: "block" }, children: [ R.text "More Please!" ] }
+                  [ R.button
+                      { onClick
+                      , style: css { display: "block" }
+                      , children: [ R.text "More Please!" ]
+                      }
                   , R.img { src: url }
                   ]
           ]
@@ -74,4 +80,10 @@ getRandomCatGif = do
   pure do
     -- Using `hush` to ignore the possible error messages
     { body } <- hush response
-    hush (decodeJson body >>= (_ .: "data") >>= (_ .: "images") >>= (_ .: "downsized") >>= (_ .: "url"))
+    hush
+      ( decodeJson body
+          >>= (_ .: "data")
+          >>= (_ .: "images")
+          >>= (_ .: "downsized")
+          >>= (_ .: "url")
+      )

--- a/recipes/ClockReactHooks/spago.dhall
+++ b/recipes/ClockReactHooks/spago.dhall
@@ -10,6 +10,7 @@
   , "prelude"
   , "react-basic-dom"
   , "react-basic-hooks"
+  , "web-dom"
   , "web-html"
   ]
 , packages = ../../packages.dhall

--- a/recipes/ClockReactHooks/src/Main.purs
+++ b/recipes/ClockReactHooks/src/Main.purs
@@ -10,51 +10,50 @@ import Data.Number (cos, sin, tau)
 import Effect (Effect)
 import Effect.Exception (throw)
 import Effect.Timer (clearInterval, setInterval)
-import React.Basic.DOM (render)
+import React.Basic.DOM.Client (createRoot, renderRoot)
 import React.Basic.DOM.SVG as SVG
 import React.Basic.Hooks (Component, Hook, JSX, UseEffect, UseState, coerceHook, component, useEffectOnce, useState', (/\))
 import React.Basic.Hooks as React
+import Web.DOM.NonElementParentNode (getElementById)
 import Web.HTML (window)
-import Web.HTML.HTMLDocument (body)
-import Web.HTML.HTMLElement (toElement)
+import Web.HTML.HTMLDocument (toNonElementParentNode)
 import Web.HTML.Window (document)
 
 type Time = { hours :: Number, minutes :: Number, seconds :: Number }
 
 main :: Effect Unit
 main = do
-  body <- body =<< document =<< window
-  case body of
-    Nothing -> throw "Could not find body."
-    Just b -> do
-      clock <- mkClock
-      render (clock {}) (toElement b)
+  doc <- document =<< window
+  root <- getElementById "root" $ toNonElementParentNode doc
+  case root of
+    Nothing -> throw "Could not find root."
+    Just container -> do
+      reactRoot <- createRoot container
+      app <- mkApp
+      renderRoot reactRoot (app {})
 
-mkClock :: Component {}
-mkClock = do
+mkApp :: Component {}
+mkApp = do
   now <- JSDate.now >>= getTime
   component "Clock" \_ -> React.do
     { hours, minutes, seconds } <- useCurrentTime now
-    pure
-      $ SVG.svg
-          { viewBox: "0 0 400 400"
-          , width: "400"
-          , height: "400"
-          , children:
-              [ SVG.circle { cx: "200", cy: "200", r: "120", fill: "#1293D8" }
-              , hand 6 60.0 (hours / 12.0)
-              , hand 6 90.0 (minutes / 60.0)
-              , hand 3 90.0 (seconds / 60.0)
-              ]
-          }
+    pure $ SVG.svg
+      { viewBox: "0 0 400 400"
+      , width: "400"
+      , height: "400"
+      , children:
+          [ SVG.circle { cx: "200", cy: "200", r: "120", fill: "#1293D8" }
+          , hand 6 60.0 (hours / 12.0)
+          , hand 6 90.0 (minutes / 60.0)
+          , hand 3 90.0 (seconds / 60.0)
+          ]
+      }
 
 hand :: Int -> Number -> Number -> JSX
 hand width length turns =
   let
     t = tau * (turns - 0.25)
-
     x = 200.0 + length * cos t
-
     y = 200.0 + length * sin t
   in
     SVG.line
@@ -69,7 +68,7 @@ hand width length turns =
 
 newtype UseCurrentTime hooks = UseCurrentTime (UseEffect Unit (UseState Time hooks))
 
-derive instance ntUseCurrentTime :: Newtype (UseCurrentTime hooks) _
+derive instance Newtype (UseCurrentTime hooks) _
 
 useCurrentTime :: Time -> Hook UseCurrentTime Time
 useCurrentTime initialTime =

--- a/recipes/ComponentsInputReactHooks/spago.dhall
+++ b/recipes/ComponentsInputReactHooks/spago.dhall
@@ -7,6 +7,7 @@
   , "react-basic"
   , "react-basic-dom"
   , "react-basic-hooks"
+  , "web-dom"
   , "web-html"
   ]
 , packages = ../../packages.dhall

--- a/recipes/ComponentsInputReactHooks/src/Main.purs
+++ b/recipes/ComponentsInputReactHooks/src/Main.purs
@@ -6,63 +6,57 @@ import Data.Maybe (Maybe(..))
 import Effect (Effect)
 import Effect.Exception (throw)
 import Effect.Unsafe (unsafePerformEffect)
-import React.Basic.DOM (render)
 import React.Basic.DOM as R
+import React.Basic.DOM.Client (createRoot, renderRoot)
 import React.Basic.Events (handler_)
-import React.Basic.Hooks
-  ( Component
-  , Render
-  , UseEffect
-  , UseRef
-  , component
-  , readRef
-  , useEffectAlways
-  , useRef
-  , useState
-  , writeRef
-  , (/\)
-  )
+import React.Basic.Hooks (Component, Render, UseEffect, UseRef, component, readRef, useEffectAlways, useRef, useState, writeRef, (/\))
 import React.Basic.Hooks as React
+import Web.DOM.NonElementParentNode (getElementById)
 import Web.HTML (window)
-import Web.HTML.HTMLDocument (body)
-import Web.HTML.HTMLElement (toElement)
+import Web.HTML.HTMLDocument (toNonElementParentNode)
 import Web.HTML.Window (document)
 
 main :: Effect Unit
 main = do
-  body <- body =<< document =<< window
-  case body of
-    Nothing -> throw "Could not find body."
-    Just b -> do
-      container <- mkContainer
-      render (container unit) (toElement b)
+  doc <- document =<< window
+  root <- getElementById "root" $ toNonElementParentNode doc
+  case root of
+    Nothing -> throw "Could not find root."
+    Just container -> do
+      reactRoot <- createRoot container
+      app <- mkApp
+      renderRoot reactRoot (app {})
 
-mkContainer :: Component Unit
-mkContainer = do
+mkApp :: Component {}
+mkApp = do
   display <- mkDisplay
   component "Container" \_ -> React.do
     parentRenders <- useRenderCount
     state /\ setState <- useState 0
-    pure
-      $ R.div_
-          [ R.ul_
-              [ display state
-              , display (state * 2)
-              , display (state * 3)
-              , display (state * 10)
-              , display (state * state)
-              ]
-          , R.button
-              { onClick: handler_ (setState (_ + 1))
-              , children: [ R.text "+1" ]
-              }
-          , R.button
-              { onClick: handler_ (setState (_ - 1))
-              , children: [ R.text "-1" ]
-              }
-          , R.p_
-              [ R.text ("Parent has been rendered " <> show parentRenders <> " time(s)") ]
+    pure $ R.div_
+      [ R.ul_
+          [ display state
+          , display (state * 2)
+          , display (state * 3)
+          , display (state * 10)
+          , display (state * state)
           ]
+      , R.button
+          { onClick: handler_ (setState (_ + 1))
+          , children: [ R.text "+1" ]
+          }
+      , R.button
+          { onClick: handler_ (setState (_ - 1))
+          , children: [ R.text "-1" ]
+          }
+      , R.p_
+          [ R.text
+              ( "Parent has been rendered "
+                  <> show parentRenders
+                  <> " time(s)"
+              )
+          ]
+      ]
 
 mkDisplay :: Component Int
 mkDisplay =
@@ -80,6 +74,5 @@ useRenderCount = React.do
     renders <- readRef rendersRef
     writeRef rendersRef (renders + 1)
     pure mempty
-  let
-    renders = unsafePerformEffect (readRef rendersRef)
+  let renders = unsafePerformEffect (readRef rendersRef)
   pure renders

--- a/recipes/ComponentsMultiTypeReactHooks/spago.dhall
+++ b/recipes/ComponentsMultiTypeReactHooks/spago.dhall
@@ -8,6 +8,7 @@
   , "react-basic-dom"
   , "react-basic-hooks"
   , "tuples"
+  , "web-dom"
   , "web-html"
   ]
 , packages = ../../packages.dhall

--- a/recipes/ComponentsReactHooks/spago.dhall
+++ b/recipes/ComponentsReactHooks/spago.dhall
@@ -7,6 +7,7 @@
   , "react-basic"
   , "react-basic-dom"
   , "react-basic-hooks"
+  , "web-dom"
   , "web-html"
   ]
 , packages = ../../packages.dhall

--- a/recipes/DragAndDropReactHooks/spago.dhall
+++ b/recipes/DragAndDropReactHooks/spago.dhall
@@ -9,6 +9,7 @@
   , "react-basic"
   , "react-basic-dom"
   , "react-basic-hooks"
+  , "web-dom"
   , "web-file"
   , "web-html"
   ]

--- a/recipes/DragAndDropReactHooks/src/Main.purs
+++ b/recipes/DragAndDropReactHooks/src/Main.purs
@@ -6,104 +6,108 @@ import Data.Foldable as Foldable
 import Data.Maybe (Maybe(..))
 import Data.Nullable as Nullable
 import Effect (Effect)
-import Effect.Exception as Exception
+import Effect.Exception (throw)
 import React.Basic.DOM as R
+import React.Basic.DOM.Client (createRoot, renderRoot)
 import React.Basic.DOM.Events as DOM.Events
 import React.Basic.Events as Events
 import React.Basic.Hooks (Component, (/\))
 import React.Basic.Hooks as React
+import Web.DOM.NonElementParentNode (getElementById)
 import Web.File.File as File
 import Web.File.FileList as FileList
-import Web.HTML as HTML
+import Web.HTML (window)
 import Web.HTML.Event.DataTransfer as DataTransfer
 import Web.HTML.Event.DragEvent as DragEvent
-import Web.HTML.HTMLDocument as HTMLDocument
+import Web.HTML.HTMLDocument (toNonElementParentNode)
 import Web.HTML.HTMLElement as HTMLElement
 import Web.HTML.HTMLInputElement as HTMLInputElement
-import Web.HTML.Window as Window
+import Web.HTML.Window (document)
 
 main :: Effect Unit
 main = do
-  maybeBody <- HTMLDocument.body =<< Window.document =<< HTML.window
-  case maybeBody of
-    Nothing -> Exception.throw "Could not find body."
-    Just body -> do
+  doc <- document =<< window
+  root <- getElementById "root" $ toNonElementParentNode doc
+  case root of
+    Nothing -> throw "Could not find root."
+    Just container -> do
+      reactRoot <- createRoot container
       app <- mkApp
-      R.render (app unit) (HTMLElement.toElement body)
+      renderRoot reactRoot (app {})
 
-mkApp :: Component Unit
-mkApp = do
-  React.component "App" \_ -> React.do
-    hover /\ setHover <- React.useState' false
-    files /\ setFiles <- React.useState []
-    fileInputRef <- React.useRef Nullable.null
-    let
-      onButtonClick =
-        Events.handler_ do
-          maybeNode <- React.readRefMaybe fileInputRef
-          Foldable.for_ (HTMLElement.fromNode =<< maybeNode) \htmlElement -> do
-            HTMLElement.click htmlElement
-    pure
-      $ R.div
-          { style:
-              R.css
-                { display: "flex"
-                , flexDirection: "column"
-                , alignItems: "center"
-                , justifyContent: "center"
-                , margin: "min(8rem, calc(50vh - 6rem)) auto"
-                , borderRadius: "1rem"
-                , inlineSize: "32rem"
-                , blockSize: "12rem"
-                , borderWidth: "0.4rem"
-                , borderStyle: "dashed"
-                , borderColor: if hover then "purple" else "lightgray"
+mkApp :: Component {}
+mkApp = React.component "App" \_ -> React.do
+  hover /\ setHover <- React.useState' false
+  files /\ setFiles <- React.useState []
+  fileInputRef <- React.useRef Nullable.null
+  let
+    onButtonClick =
+      Events.handler_ do
+        maybeNode <- React.readRefMaybe fileInputRef
+        Foldable.for_ (HTMLElement.fromNode =<< maybeNode) \htmlElement -> do
+          HTMLElement.click htmlElement
+  pure
+    $ R.div
+        { style:
+            R.css
+              { display: "flex"
+              , flexDirection: "column"
+              , alignItems: "center"
+              , justifyContent: "center"
+              , margin: "min(8rem, calc(50vh - 6rem)) auto"
+              , borderRadius: "1rem"
+              , inlineSize: "32rem"
+              , blockSize: "12rem"
+              , borderWidth: "0.4rem"
+              , borderStyle: "dashed"
+              , borderColor: if hover then "purple" else "lightgray"
+              }
+        , onDragEnter:
+            Events.handler_ do
+              setHover true
+        , onDragLeave:
+            Events.handler_ do
+              setHover false
+        , onDragOver:
+            Events.handler DOM.Events.preventDefault \_ -> do
+              setHover true
+        , onDrop:
+            Events.handler (DOM.Events.preventDefault >>> DOM.Events.nativeEvent) \e -> do
+              setHover false
+              let
+                maybeFileList = DataTransfer.files
+                  =<< DragEvent.dataTransfer <$> DragEvent.fromEvent e
+              Foldable.for_ (FileList.items <$> maybeFileList) (setFiles <<< (<>))
+        , children:
+            [ R.button
+                { onClick: onButtonClick
+                , children: [ R.text "Upload Images" ]
                 }
-          , onDragEnter:
-              Events.handler_ do
-                setHover true
-          , onDragLeave:
-              Events.handler_ do
-                setHover false
-          , onDragOver:
-              Events.handler DOM.Events.preventDefault \_ -> do
-                setHover true
-          , onDrop:
-              Events.handler (DOM.Events.preventDefault >>> DOM.Events.nativeEvent) \e -> do
-                setHover false
-                let
-                  maybeFileList = DataTransfer.files =<< DragEvent.dataTransfer <$> DragEvent.fromEvent e
-                Foldable.for_ (FileList.items <$> maybeFileList) (setFiles <<< (<>))
-          , children:
-              [ R.button
-                  { onClick: onButtonClick
-                  , children: [ R.text "Upload Images" ]
-                  }
-              , R.input
-                  { ref: fileInputRef
-                  , hidden: true
-                  , type: "file"
-                  , multiple: true
-                  , accept: "image/*"
-                  , onChange:
-                      Events.handler DOM.Events.currentTarget \target ->
-                        Foldable.for_ (HTMLInputElement.fromEventTarget target) \fileInput -> do
-                          maybeFileList <- HTMLInputElement.files fileInput
-                          Foldable.for_ (FileList.items <$> maybeFileList) (setFiles <<< (<>))
-                  }
-              , R.pre
-                  { style:
-                      R.css
-                        { color: "gray"
-                        , whiteSpace: "break-spaces"
-                        , textAlign: "center"
-                        , overflow: "hidden"
-                        , textOverflow: "ellipsis"
-                        , inlineSize: "100%"
-                        }
-                  , children:
-                      [ R.text (show { hover, files: File.name <$> files })
-                      ]
-                  }
-              ]
-          }
+            , R.input
+                { ref: fileInputRef
+                , hidden: true
+                , type: "file"
+                , multiple: true
+                , accept: "image/*"
+                , onChange:
+                    Events.handler DOM.Events.currentTarget \target ->
+                      Foldable.for_ (HTMLInputElement.fromEventTarget target) \fileInput -> do
+                        maybeFileList <- HTMLInputElement.files fileInput
+                        Foldable.for_ (FileList.items <$> maybeFileList) (setFiles <<< (<>))
+                }
+            , R.pre
+                { style:
+                    R.css
+                      { color: "gray"
+                      , whiteSpace: "break-spaces"
+                      , textAlign: "center"
+                      , overflow: "hidden"
+                      , textOverflow: "ellipsis"
+                      , inlineSize: "100%"
+                      }
+                , children:
+                    [ R.text (show { hover, files: File.name <$> files })
+                    ]
+                }
+            ]
+        }

--- a/recipes/FileUploadReactHooks/spago.dhall
+++ b/recipes/FileUploadReactHooks/spago.dhall
@@ -8,6 +8,7 @@
   , "react-basic"
   , "react-basic-dom"
   , "react-basic-hooks"
+  , "web-dom"
   , "web-file"
   , "web-html"
   ]

--- a/recipes/FileUploadReactHooks/src/Main.purs
+++ b/recipes/FileUploadReactHooks/src/Main.purs
@@ -6,31 +6,33 @@ import Data.Foldable (for_)
 import Data.Maybe (Maybe(..))
 import Effect (Effect)
 import Effect.Exception (throw)
-import React.Basic.DOM (render)
 import React.Basic.DOM as R
+import React.Basic.DOM.Client (createRoot, renderRoot)
 import React.Basic.DOM.Events (currentTarget)
 import React.Basic.Events (handler)
 import React.Basic.Hooks (Component, component, fragment, useState', (/\))
 import React.Basic.Hooks as React
+import Web.DOM.NonElementParentNode (getElementById)
 import Web.File.File as File
 import Web.File.FileList as FileList
 import Web.HTML (window)
-import Web.HTML.HTMLDocument (body)
-import Web.HTML.HTMLElement (toElement)
+import Web.HTML.HTMLDocument (toNonElementParentNode)
 import Web.HTML.HTMLInputElement as HTMLInputElement
 import Web.HTML.Window (document)
 
 main :: Effect Unit
 main = do
-  body <- body =<< document =<< window
-  case body of
-    Nothing -> throw "Could not find body."
-    Just b -> do
-      fileUploadComponent <- mkFileUploadComponent
-      render (fileUploadComponent {}) (toElement b)
+  doc <- document =<< window
+  root <- getElementById "root" $ toNonElementParentNode doc
+  case root of
+    Nothing -> throw "Could not find root."
+    Just container -> do
+      reactRoot <- createRoot container
+      app <- mkApp
+      renderRoot reactRoot (app {})
 
-mkFileUploadComponent :: Component {}
-mkFileUploadComponent = do
+mkApp :: Component {}
+mkApp = do
   component "FileUploadComponent" \_ -> React.do
     fileList /\ setFileList <- useState' []
     let

--- a/recipes/FormsReactHooks/spago.dhall
+++ b/recipes/FormsReactHooks/spago.dhall
@@ -7,6 +7,7 @@
   , "react-basic"
   , "react-basic-dom"
   , "react-basic-hooks"
+  , "web-dom"
   , "web-html"
   ]
 , packages = ../../packages.dhall

--- a/recipes/FormsReactHooks/src/Main.purs
+++ b/recipes/FormsReactHooks/src/Main.purs
@@ -5,70 +5,67 @@ import Prelude
 import Data.Maybe (Maybe(..), fromMaybe)
 import Effect (Effect)
 import Effect.Exception (throw)
-import React.Basic.DOM (css, render)
+import React.Basic.DOM (css)
 import React.Basic.DOM as R
+import React.Basic.DOM.Client (createRoot, renderRoot)
 import React.Basic.DOM.Events (preventDefault, targetValue)
 import React.Basic.Events (EventHandler, handler)
 import React.Basic.Hooks (type (/\), Component, Hook, UseState, component, useState, (/\))
 import React.Basic.Hooks as React
+import Web.DOM.NonElementParentNode (getElementById)
 import Web.HTML (window)
-import Web.HTML.HTMLDocument (body)
-import Web.HTML.HTMLElement (toElement)
+import Web.HTML.HTMLDocument (toNonElementParentNode)
 import Web.HTML.Window (document)
 
 main :: Effect Unit
 main = do
-  body <- body =<< document =<< window
-  case body of
-    Nothing -> throw "Could not find body."
-    Just b -> do
-      form <- mkForm
-      render (form {}) (toElement b)
+  doc <- document =<< window
+  root <- getElementById "root" $ toNonElementParentNode doc
+  case root of
+    Nothing -> throw "Could not find root."
+    Just container -> do
+      reactRoot <- createRoot container
+      app <- mkApp
+      renderRoot reactRoot (app {})
 
-mkForm :: Component {}
-mkForm = do
-  component "Form" \_ -> React.do
-    name /\ onNameChange <- useInput ""
-    password /\ onPasswordChange <- useInput ""
-    passwordAgain /\ onPasswordAgainChange <- useInput ""
-    let
-      renderValidation =
-        if password == passwordAgain then
-          R.div { style: css { color: "green" }, children: [ R.text "OK" ] }
-        else
-          R.div { style: css { color: "red" }, children: [ R.text "Passwords do not match!" ] }
-    pure
-      $ R.form
-          { onSubmit: handler preventDefault mempty
-          , children:
-              [ R.input
-                  { placeholder: "Name"
-                  , value: name
-                  , onChange: onNameChange
-                  }
-              , R.input
-                  { type: "password"
-                  , placeholder: "Password"
-                  , value: password
-                  , onChange: onPasswordChange
-                  }
-              , R.input
-                  { type: "password"
-                  , placeholder: "Re-enter Password"
-                  , value: passwordAgain
-                  , onChange: onPasswordAgainChange
-                  }
-              , renderValidation
-              ]
-          }
+mkApp :: Component {}
+mkApp = component "Form" \_ -> React.do
+  name /\ onNameChange <- useInput ""
+  password /\ onPasswordChange <- useInput ""
+  passwordAgain /\ onPasswordAgainChange <- useInput ""
+  let
+    renderValidation =
+      if password == passwordAgain then
+        R.div { style: css { color: "green" }, children: [ R.text "OK" ] }
+      else
+        R.div { style: css { color: "red" }, children: [ R.text "Passwords do not match!" ] }
+  pure
+    $ R.form
+        { onSubmit: handler preventDefault mempty
+        , children:
+            [ R.input
+                { placeholder: "Name"
+                , value: name
+                , onChange: onNameChange
+                }
+            , R.input
+                { type: "password"
+                , placeholder: "Password"
+                , value: password
+                , onChange: onPasswordChange
+                }
+            , R.input
+                { type: "password"
+                , placeholder: "Re-enter Password"
+                , value: passwordAgain
+                , onChange: onPasswordAgainChange
+                }
+            , renderValidation
+            ]
+        }
 
-useInput
-  :: String
-  -> Hook
-       (UseState String)
-       (String /\ EventHandler)
+useInput :: String -> Hook (UseState String) (String /\ EventHandler)
 useInput initialValue = React.do
   value /\ setValue <- useState initialValue
-  let
-    onChange = handler targetValue (setValue <<< const <<< fromMaybe "")
+  let onChange = handler targetValue (setValue <<< const <<< fromMaybe "")
   pure (value /\ onChange)

--- a/recipes/GroceriesReactHooks/spago.dhall
+++ b/recipes/GroceriesReactHooks/spago.dhall
@@ -6,6 +6,7 @@
   , "prelude"
   , "react-basic-dom"
   , "react-basic-hooks"
+  , "web-dom"
   , "web-html"
   ]
 , packages = ../../packages.dhall

--- a/recipes/GroceriesReactHooks/src/Main.purs
+++ b/recipes/GroceriesReactHooks/src/Main.purs
@@ -5,37 +5,39 @@ import Prelude
 import Data.Maybe (Maybe(..))
 import Effect (Effect)
 import Effect.Exception (throw)
-import React.Basic.DOM (div_, h1_, li_, render, text, ul_)
+import React.Basic.DOM (div_, h1_, li_, text, ul_)
+import React.Basic.DOM.Client (createRoot, renderRoot)
 import React.Basic.Hooks (Component, component)
+import Web.DOM.NonElementParentNode (getElementById)
 import Web.HTML (window)
-import Web.HTML.HTMLDocument (body)
-import Web.HTML.HTMLElement (toElement)
+import Web.HTML.HTMLDocument (toNonElementParentNode)
 import Web.HTML.Window (document)
 
 main :: Effect Unit
 main = do
-  body <- body =<< document =<< window
-  case body of
-    Nothing -> throw "Root element not found."
-    Just b -> do
-      groceries <- mkGroceries
-      render (groceries {}) (toElement b)
+  doc <- document =<< window
+  root <- getElementById "root" $ toNonElementParentNode doc
+  case root of
+    Nothing -> throw "Could not find root."
+    Just container -> do
+      reactRoot <- createRoot container
+      app <- mkApp
+      renderRoot reactRoot (app {})
 
-mkGroceries :: Component {}
-mkGroceries = do
-  component "Groceries" \_ -> React.do
-    pure
-      $ div_
-          [ h1_ [ text "My Grocery List" ]
-          , ul_
-              [ li_ [ text "Black Beans" ]
-              , li_ [ text "Limes" ]
-              , li_ [ text "Greek Yogurt" ]
-              , li_ [ text "Cilantro" ]
-              , li_ [ text "Honey" ]
-              , li_ [ text "Sweet Potatoes" ]
-              , li_ [ text "Cumin" ]
-              , li_ [ text "Chili Powder" ]
-              , li_ [ text "Quinoa" ]
-              ]
-          ]
+mkApp :: Component {}
+mkApp = component "Groceries" \_ -> React.do
+  pure
+    $ div_
+        [ h1_ [ text "My Grocery List" ]
+        , ul_
+            [ li_ [ text "Black Beans" ]
+            , li_ [ text "Limes" ]
+            , li_ [ text "Greek Yogurt" ]
+            , li_ [ text "Cilantro" ]
+            , li_ [ text "Honey" ]
+            , li_ [ text "Sweet Potatoes" ]
+            , li_ [ text "Cumin" ]
+            , li_ [ text "Chili Powder" ]
+            , li_ [ text "Quinoa" ]
+            ]
+        ]

--- a/recipes/ImagePreviewsReactHooks/spago.dhall
+++ b/recipes/ImagePreviewsReactHooks/spago.dhall
@@ -11,6 +11,7 @@
   , "react-basic-dom"
   , "react-basic-hooks"
   , "unsafe-coerce"
+  , "web-dom"
   , "web-file"
   , "web-html"
   ]

--- a/recipes/NumbersReactHooks/spago.dhall
+++ b/recipes/NumbersReactHooks/spago.dhall
@@ -8,6 +8,7 @@
   , "react-basic"
   , "react-basic-dom"
   , "react-basic-hooks"
+  , "web-dom"
   , "web-html"
   ]
 , packages = ../../packages.dhall

--- a/recipes/NumbersReactHooks/src/Main.purs
+++ b/recipes/NumbersReactHooks/src/Main.purs
@@ -6,27 +6,29 @@ import Data.Maybe (Maybe(..))
 import Effect (Effect)
 import Effect.Exception (throw)
 import Effect.Random (randomInt)
-import React.Basic.DOM (render)
 import React.Basic.DOM as R
+import React.Basic.DOM.Client (createRoot, renderRoot)
 import React.Basic.Events (handler_)
 import React.Basic.Hooks (Component, component, useState', (/\))
 import React.Basic.Hooks as React
+import Web.DOM.NonElementParentNode (getElementById)
 import Web.HTML (window)
-import Web.HTML.HTMLDocument (body)
-import Web.HTML.HTMLElement (toElement)
+import Web.HTML.HTMLDocument (toNonElementParentNode)
 import Web.HTML.Window (document)
 
 main :: Effect Unit
 main = do
-  body <- body =<< document =<< window
-  case body of
-    Nothing -> throw "Could not find body."
-    Just b -> do
-      numbers <- mkNumbers
-      render (numbers {}) (toElement b)
+  doc <- document =<< window
+  root <- getElementById "root" $ toNonElementParentNode doc
+  case root of
+    Nothing -> throw "Could not find root."
+    Just container -> do
+      reactRoot <- createRoot container
+      app <- mkApp
+      renderRoot reactRoot (app {})
 
-mkNumbers :: Component {}
-mkNumbers = do
+mkApp :: Component {}
+mkApp =
   component "Numbers" \_ -> React.do
     roll /\ setRoll <- useState' 1
     let

--- a/recipes/PositionsReactHooks/spago.dhall
+++ b/recipes/PositionsReactHooks/spago.dhall
@@ -8,6 +8,7 @@
   , "react-basic"
   , "react-basic-dom"
   , "react-basic-hooks"
+  , "web-dom"
   , "web-html"
   ]
 , packages = ../../packages.dhall

--- a/recipes/PositionsReactHooks/src/Main.purs
+++ b/recipes/PositionsReactHooks/src/Main.purs
@@ -6,27 +6,30 @@ import Data.Maybe (Maybe(..))
 import Effect (Effect)
 import Effect.Exception (throw)
 import Effect.Random (randomInt)
-import React.Basic.DOM (css, render)
+import React.Basic.DOM (css)
 import React.Basic.DOM as R
+import React.Basic.DOM.Client (createRoot, renderRoot)
 import React.Basic.Events (handler_)
 import React.Basic.Hooks (Component, component, useState', (/\))
 import React.Basic.Hooks as React
+import Web.DOM.NonElementParentNode (getElementById)
 import Web.HTML (window)
-import Web.HTML.HTMLDocument (body)
-import Web.HTML.HTMLElement (toElement)
+import Web.HTML.HTMLDocument (toNonElementParentNode)
 import Web.HTML.Window (document)
 
 main :: Effect Unit
 main = do
-  body <- body =<< document =<< window
-  case body of
-    Nothing -> throw "Could not find body."
-    Just b -> do
-      positions <- mkPositions
-      render (positions {}) (toElement b)
+  doc <- document =<< window
+  root <- getElementById "root" $ toNonElementParentNode doc
+  case root of
+    Nothing -> throw "Could not find root."
+    Just container -> do
+      reactRoot <- createRoot container
+      app <- mkApp
+      renderRoot reactRoot (app {})
 
-mkPositions :: Component {}
-mkPositions = do
+mkApp :: Component {}
+mkApp =
   component "Positions" \_ -> React.do
     { x, y } /\ setPosition <- useState' { x: 100, y: 100 }
     let

--- a/recipes/RoutingHashReactHooks/spago.dhall
+++ b/recipes/RoutingHashReactHooks/spago.dhall
@@ -11,6 +11,7 @@
   , "react-basic-hooks"
   , "routing"
   , "strings"
+  , "web-dom"
   , "web-html"
   ]
 , packages = ../../packages.dhall

--- a/recipes/RoutingHashReactHooks/web/index.html
+++ b/recipes/RoutingHashReactHooks/web/index.html
@@ -1,13 +1,12 @@
 <!DOCTYPE html>
 <html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>RoutingHashReactHooks</title>
+  </head>
 
-<head>
-  <meta charset="UTF-8">
-  <title>RoutingHashReactHooks</title>
-</head>
-
-<body>
-  <script type="module" src="./index.js"></script>
-</body>
-
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./index.js"></script>
+  </body>
 </html>

--- a/recipes/RoutingPushReactHooks/spago.dhall
+++ b/recipes/RoutingPushReactHooks/spago.dhall
@@ -13,6 +13,7 @@
   , "react-basic-hooks"
   , "routing"
   , "transformers"
+  , "web-dom"
   , "web-html"
   ]
 , packages = ../../packages.dhall

--- a/recipes/RoutingPushReactHooks/web/index.html
+++ b/recipes/RoutingPushReactHooks/web/index.html
@@ -1,13 +1,12 @@
 <!DOCTYPE html>
 <html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>RoutingPushReactHooks</title>
+  </head>
 
-<head>
-  <meta charset="UTF-8">
-  <title>RoutingPushReactHooks</title>
-</head>
-
-<body>
-  <script type="module" src="./index.js"></script>
-</body>
-
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./index.js"></script>
+  </body>
 </html>

--- a/recipes/ShapesReactHooks/spago.dhall
+++ b/recipes/ShapesReactHooks/spago.dhall
@@ -6,6 +6,7 @@
   , "prelude"
   , "react-basic-dom"
   , "react-basic-hooks"
+  , "web-dom"
   , "web-html"
   ]
 , packages = ../../packages.dhall

--- a/recipes/ShapesReactHooks/src/Main.purs
+++ b/recipes/ShapesReactHooks/src/Main.purs
@@ -5,25 +5,28 @@ import Prelude
 import Data.Maybe (Maybe(..))
 import Effect (Effect)
 import Effect.Exception (throw)
-import React.Basic.DOM (render, text)
+import React.Basic.DOM (text)
+import React.Basic.DOM.Client (createRoot, renderRoot)
 import React.Basic.DOM.SVG as R
 import React.Basic.Hooks (Component, component)
+import Web.DOM.NonElementParentNode (getElementById)
 import Web.HTML (window)
-import Web.HTML.HTMLDocument (body)
-import Web.HTML.HTMLElement (toElement)
+import Web.HTML.HTMLDocument (toNonElementParentNode)
 import Web.HTML.Window (document)
 
 main :: Effect Unit
 main = do
-  body <- body =<< document =<< window
-  case body of
-    Nothing -> throw "Could not find body."
-    Just b -> do
-      shapesComponent <- mkShapesComponent
-      render (shapesComponent unit) (toElement b)
+  doc <- document =<< window
+  root <- getElementById "root" $ toNonElementParentNode doc
+  case root of
+    Nothing -> throw "Could not find root."
+    Just container -> do
+      reactRoot <- createRoot container
+      app <- mkApp
+      renderRoot reactRoot (app {})
 
-mkShapesComponent :: Component Unit
-mkShapesComponent = do
+mkApp :: Component {}
+mkApp =
   component "ShapesComponent" \_ -> React.do
     pure
       $ R.svg

--- a/recipes/TextFieldsReactHooks/spago.dhall
+++ b/recipes/TextFieldsReactHooks/spago.dhall
@@ -9,6 +9,7 @@
   , "react-basic-dom"
   , "react-basic-hooks"
   , "strings"
+  , "web-dom"
   , "web-html"
   ]
 , packages = ../../packages.dhall

--- a/recipes/TextFieldsReactHooks/src/Main.purs
+++ b/recipes/TextFieldsReactHooks/src/Main.purs
@@ -7,37 +7,37 @@ import Data.Maybe (Maybe(..), fromMaybe)
 import Data.String (fromCodePointArray, toCodePointArray)
 import Effect (Effect)
 import Effect.Exception (throw)
-import React.Basic.DOM (render)
 import React.Basic.DOM as R
+import React.Basic.DOM.Client (createRoot, renderRoot)
 import React.Basic.DOM.Events (targetValue)
 import React.Basic.Events (handler)
 import React.Basic.Hooks (Component, component, useState, (/\))
 import React.Basic.Hooks as React
+import Web.DOM.NonElementParentNode (getElementById)
 import Web.HTML (window)
-import Web.HTML.HTMLDocument (body)
-import Web.HTML.HTMLElement (toElement)
+import Web.HTML.HTMLDocument (toNonElementParentNode)
 import Web.HTML.Window (document)
 
 main :: Effect Unit
 main = do
-  body <- body =<< document =<< window
-  case body of
-    Nothing -> throw "Could not find body."
-    Just b -> do
-      textField <- mkTextField
-      render (textField {}) (toElement b)
+  doc <- document =<< window
+  root <- getElementById "root" $ toNonElementParentNode doc
+  case root of
+    Nothing -> throw "Could not find root."
+    Just container -> do
+      reactRoot <- createRoot container
+      app <- mkApp
+      renderRoot reactRoot (app {})
 
-mkTextField :: Component {}
-mkTextField = do
+mkApp :: Component {}
+mkApp =
   component "TextField" \_ -> React.do
     content /\ setContent <- useState ""
-    let
-      onChange = handler targetValue (setContent <<< const <<< fromMaybe "")
-    pure
-      $ R.div_
-          [ R.input { placeholder: "Text to reverse", value: content, onChange }
-          , R.div_ [ R.text (reverse content) ]
-          ]
+    let onChange = handler targetValue (setContent <<< const <<< fromMaybe "")
+    pure $ R.div_
+      [ R.input { placeholder: "Text to reverse", value: content, onChange }
+      , R.div_ [ R.text (reverse content) ]
+      ]
 
 reverse :: String -> String
 reverse = fromCodePointArray <<< Array.reverse <<< toCodePointArray

--- a/recipes/TicTacToeReactHooks/spago.dhall
+++ b/recipes/TicTacToeReactHooks/spago.dhall
@@ -11,6 +11,7 @@
   , "react-basic"
   , "react-basic-dom"
   , "react-basic-hooks"
+  , "web-dom"
   , "web-html"
   ]
 , packages = ../../packages.dhall

--- a/recipes/TimeReactHooks/spago.dhall
+++ b/recipes/TimeReactHooks/spago.dhall
@@ -11,6 +11,7 @@
   , "prelude"
   , "react-basic-dom"
   , "react-basic-hooks"
+  , "web-dom"
   , "web-html"
   ]
 , packages = ../../packages.dhall

--- a/recipes/TimeReactHooks/src/Main.purs
+++ b/recipes/TimeReactHooks/src/Main.purs
@@ -11,28 +11,30 @@ import Data.Newtype (class Newtype)
 import Effect (Effect)
 import Effect.Exception (throw)
 import Effect.Timer (clearInterval, setInterval)
-import React.Basic.DOM (render)
 import React.Basic.DOM as R
+import React.Basic.DOM.Client (createRoot, renderRoot)
 import React.Basic.Hooks (Component, Hook, UseEffect, UseState, coerceHook, component, useEffectOnce, useState', (/\))
 import React.Basic.Hooks as React
+import Web.DOM.NonElementParentNode (getElementById)
 import Web.HTML (window)
-import Web.HTML.HTMLDocument (body)
-import Web.HTML.HTMLElement (toElement)
+import Web.HTML.HTMLDocument (toNonElementParentNode)
 import Web.HTML.Window (document)
 
 type Time = { hours :: Int, minutes :: Int, seconds :: Int }
 
 main :: Effect Unit
 main = do
-  body <- body =<< document =<< window
-  case body of
-    Nothing -> throw "Could not find body."
-    Just b -> do
-      time <- mkTime
-      render (time {}) (toElement b)
+  doc <- document =<< window
+  root <- getElementById "root" $ toNonElementParentNode doc
+  case root of
+    Nothing -> throw "Could not find root."
+    Just container -> do
+      reactRoot <- createRoot container
+      app <- mkApp
+      renderRoot reactRoot (app {})
 
-mkTime :: Component {}
-mkTime = do
+mkApp :: Component {}
+mkApp = do
   now <- JSDate.now >>= getTime
   component "Time" \_ -> React.do
     { hours, minutes, seconds } <- useCurrentTime now
@@ -48,7 +50,7 @@ mkTime = do
 
 newtype UseCurrentTime hooks = UseCurrentTime (UseEffect Unit (UseState Time hooks))
 
-derive instance ntUseCurrentTime :: Newtype (UseCurrentTime hooks) _
+derive instance Newtype (UseCurrentTime hooks) _
 
 useCurrentTime :: Time -> Hook UseCurrentTime Time
 useCurrentTime initialTime =


### PR DESCRIPTION
Updated react hooks examples to render in `#root` to avoid `body` warning and use new `createRoot` function to avoid deprecation warning.

* Two examples had a different `index.html`
* The component is now consistently `mkApp :: Component {}` in all examples
* Only [`RoutingPushReactHooks`](https://github.com/JordanMartinez/purescript-cookbook/pull/298/commits/aab6f09916d3371cb1f22ff3df700f68f3bbaf09#diff-0f8a853cb9c5828d673267088d4a59779d9fb7d1816a2b1e721a17b53a08e812R43) has a different `main` function because of `routerProvider` with `ReaderT`
* Tiny line break improvements (e.g. one line lets)

## Examples

- [x] HelloReactHooks (updated in previous PR https://github.com/JordanMartinez/purescript-cookbook/pull/294)
- [x] BookReactHooks
- [x] ButtonsReactHooks
- [x] CardsReactHooks
- [x] CatGifsReactHooks
- [x] ClockReactHooks
- [x] ComponentsInputReactHooks
- [x] ComponentsMultiTypeReactHooks
- [x] ComponentsReactHooks
- [x] DragAndDropReactHooks
- [x] FileUploadReactHooks
- [x] FormsReactHooks
- [x] GroceriesReactHooks
- [x] ImagePreviewsReactHooks
- [x] NumbersReactHooks
- [x] PositionsReactHooks
- [x] RoutingHashReactHooks
- [x] RoutingPushReactHooks
- [x] ShapesReactHooks
- [x] TextFieldsReactHooks
- [x] TicTacToeReactHooks
- [x] TimeReactHooks

## Related

* Based on / merge after https://github.com/JordanMartinez/purescript-cookbook/pull/296
* Package set in sync with https://github.com/purescript/trypurescript/pull/294 (`createRoot`)

## Review

Actual diff (without formatting PR) can be better viewed by [comparing this and the base branch](https://github.com/andys8/purescript-cookbook/compare/improvement/format-purs-tidy...andys8:purescript-cookbook:update-react-examples-to-v18)

