### PR TITLE
Bump nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -9,8 +9,8 @@ let
       # ```
       # $ nix-prefetch-git https://github.com/justinwoo/easy-purescript-nix.git
       # ```
-      rev = "bbef4245cd6810ea84e97a47c801947bfec9fadc";
-      sha256 = "00764zbwhbn61jwb5px2syzi2f9djyl8fmbd2p8wma985af54iwx";
+      rev = "3d8b602e80c0fa7d97d7f03cb8e2f8b06967d509";
+      sha256 = "0kvnsc4j0h8qvv69613781i2qy51rcbmv5ga8j21nsqzy3l8fd9w";
     }
   ) {
     inherit pkgs;


### PR DESCRIPTION
Fixes #299.

This `rev` and `sha` are the latest from running `nix-prefetch-git https://github.com/justinwoo/easy-purescript-nix.git`.

We might just want to delete this `shell.nix`, I for one am not especially interested in maintaining it, and it doesn't seem like other maintainers use `nix`. Some past discussion here: https://github.com/JordanMartinez/purescript-cookbook/pull/264#issuecomment-775652106