### PR TITLE
CI: Bump Node version to latest LTS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Node toolchain
         uses: actions/setup-node@v1
         with:
-          node-version: "12.x"
+          node-version: "18.x"
 
       - name: Cache NPM dependencies
         uses: actions/cache@v2


### PR DESCRIPTION
Seeing the following error in the CI build for #304 
```
=== Building HelloLog for the web browser backend ===
/home/runner/work/purescript-cookbook/purescript-cookbook/node_modules/@parcel/utils/lib/index.js:37573
    #getIndex(item) {
             ^

SyntaxError: Unexpected token '('
```
`#getIndex` is using relatively new [private class field](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields) syntax. According to MDN, that should be valid in Node v12 so I'm not sure why this is failing with a syntax error. Trying to bump to v18 to see if that helps.
